### PR TITLE
Add badge to README to indicate latest pypi version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mythril
 
-[![PyPI](https://img.shields.io/pypi/v/mythril.svg)](https://pypi.python.org/pypi/mythril)
+[![PyPI](https://badge.fury.io/py/mythril.svg)](https://pypi.python.org/pypi/mythril)
 
 <img height="120px" align="right" src="/static/mythril.png"/>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mythril
 
+[![PyPI](https://img.shields.io/pypi/v/mythril.svg)](https://pypi.python.org/pypi/mythril)
+
 <img height="120px" align="right" src="/static/mythril.png"/>
 
 Mythril is a security analysis tool for Ethereum smart contracts. It uses the [LASER-ethereum symbolic virtual machine](https://github.com/b-mueller/laser-ethereum) to detect [various types of issues](security_checks.md). Use it to analyze source code or as a nmap-style black-box blockchain scanner (an "ethermap" if you will).


### PR DESCRIPTION
An issue with the recent tickets I've submitted (#75, #76) comes from not having the latest version. Since this project actively being developed, it may be useful to have the current pypi version programmatically displayed on the README. This uses 

https://badge.fury.io/

to render the badge, with the version taken from pypi itself. It should render like this:

[![PyPI](https://badge.fury.io/py/mythril.svg)](https://pypi.python.org/pypi/mythril)