### PR TITLE
Fix #92. Remove compiler related methods since they are gone from eth…

### DIFF
--- a/mythril/rpc/base_client.py
+++ b/mythril/rpc/base_client.py
@@ -425,38 +425,6 @@ class BaseClient(object):
         block = validate_block(block)
         return self._call('eth_getUncleByBlockNumberAndIndex', [block, hex(index)])
 
-    def eth_getCompilers(self):
-        '''
-        https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getcompilers
-
-        TESTED
-        '''
-        return self._call('eth_getCompilers')
-
-    def eth_compileSolidity(self, code):
-        '''
-        https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_compilesolidity
-
-        TESTED
-        '''
-        return self._call('eth_compileSolidity', [code])
-
-    def eth_compileLLL(self, code):
-        '''
-        https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_compilelll
-
-        N/A
-        '''
-        return self._call('eth_compileLLL', [code])
-
-    def eth_compileSerpent(self, code):
-        '''
-        https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_compileserpent
-
-        N/A
-        '''
-        return self._call('eth_compileSerpent', [code])
-
     def eth_newFilter(self, from_block=BLOCK_TAG_LATEST, to_block=BLOCK_TAG_LATEST, address=None, topics=None):
         '''
         https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter


### PR DESCRIPTION
Remove compiler related methods since they are gone from eth, see: <https://github.com/ethereum/go-ethereum/issues/3793>