### PR TITLE
fix #90: try speeding up ipc reading

### DIFF
--- a/mythril/ether/__init__.py
+++ b/mythril/ether/__init__.py
@@ -1,0 +1,3 @@
+import time
+
+start_time = time.time()

--- a/mythril/ether/contractstorage.py
+++ b/mythril/ether/contractstorage.py
@@ -1,6 +1,5 @@
 import os
 import hashlib
-import persistent
 import persistent.list
 import transaction
 from BTrees.OOBTree import BTree
@@ -9,7 +8,8 @@ from ZODB import FileStorage
 from multiprocessing import Pool
 import logging
 from mythril.ether.ethcontract import ETHContract, InstanceList
-
+from mythril import ether
+import time
 
 BLOCKS_PER_THREAD = 256
 NUM_THREADS = 8
@@ -128,7 +128,9 @@ class ContractStorage(persistent.Persistent):
             processed += NUM_THREADS * BLOCKS_PER_THREAD
             self.last_block = blockNum
             transaction.commit()
-            print("%d blocks processed, %d unique contracts in database, next block: %d" % (processed, len(self.contracts), blockNum))
+
+            cost_time = time.time() - ether.start_time
+            print("%d blocks processed (in %d seconds), %d unique contracts in database, next block: %d" % (processed, cost_time, len(self.contracts), blockNum))
 
         # If we've finished initializing the database, start over from the end of the chain if we want to initialize again
         self.last_block = 0

--- a/mythril/ipc/client.py
+++ b/mythril/ipc/client.py
@@ -3,6 +3,7 @@ import socket
 
 from mythril.rpc.base_client import BaseClient
 from .utils import (get_default_ipc_path, to_text, to_bytes)
+import threading
 
 try:
     from json import JSONDecodeError
@@ -18,6 +19,8 @@ This code is mostly adapted from:
 - https://github.com/ethereum/web3.py
 '''
 
+# use thread local to store socket which will be reused just in owner thread
+THREAD_LOCAL = threading.local()
 
 class EthIpc(BaseClient):
 
@@ -26,12 +29,45 @@ class EthIpc(BaseClient):
             ipc_path = get_default_ipc_path(testnet)
         self.ipc_path = ipc_path
 
+    def connect_if_not_yet(self):
+        if not hasattr(THREAD_LOCAL, "socket"):
+            THREAD_LOCAL.socket = self.get_socket()
+
+    def reconnect(self):
+        self.close()
+        THREAD_LOCAL.socket = self.get_socket()
+
+    @staticmethod
+    def close():
+        if THREAD_LOCAL.socket is not None:
+            try:
+                THREAD_LOCAL.socket.close()
+            except socket.error:
+                pass
+
     def get_socket(self):
         _socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         _socket.connect(self.ipc_path)
         # Tell the socket not to block on reads.
-        _socket.settimeout(0.2)
+        _socket.settimeout(2)
         return _socket
+
+    @staticmethod
+    def send_request(request):
+        THREAD_LOCAL.socket.sendall(request)
+
+    @staticmethod
+    def read_response():
+        response_raw = ""
+        while True:
+            response_raw += to_text(THREAD_LOCAL.socket.recv(4096))
+            # print("response_raw: " + response_raw)
+            trimmed = response_raw.strip()
+            if trimmed and trimmed[-1] == '}':
+                try:
+                    return json.loads(trimmed)
+                except JSONDecodeError:
+                    continue
 
     def _call(self, method, params=None, _id=1):
         params = params or []
@@ -42,30 +78,18 @@ class EthIpc(BaseClient):
             'id': _id,
         }
         request = to_bytes(json.dumps(data))
-        _socket = self.get_socket()
+
+        self.connect_if_not_yet()
 
         for _ in range(3):
-            _socket.sendall(request)
-            response_raw = ""
-
-            while True:
-                try:
-                    response_raw += to_text(_socket.recv(4096))
-                except socket.timeout:
-                    break
-
-            if response_raw == "":
-                _socket.close()
-                _socket = self.get_socket()
-                continue
-
-            _socket.close()
-
-            break
+            try:
+                self.send_request(request)
+                response = self.read_response()
+                break
+            except socket.timeout or OSError:
+                self.reconnect()
         else:
             raise ValueError("No JSON returned by socket")
-
-        response = json.loads(response_raw)
 
         if "error" in response:
             raise ValueError(response["error"]["message"])


### PR DESCRIPTION
I see in this issue: <https://github.com/ConsenSys/mythril/issues/90>, current myth is quite slow to read data from ipc socket after removing web.py.

Current implementation of reading data from socket, has 2 issues with performance I think:

1. it connects the ipc socket every time, and the operation is expensive
2. it doesn't know if the response is complete, so it will still call `socket.recv` until the time is out, and the timeout is at least 0.2 second

The implementation is inspired from web3.py.

When I run the code (by command `myth --init-db`), it show me about 1 second for each IPC call, which is too slow (if you add `print(blockNumber)` in `contractstorage.py#initialize`)

In this PR, I tried 2 improvements:

1. reuse the socket all the time, across ipc calls, to reduce the connection cost. And the socket will be re-created only if we can't read data from it (raised `socket.timeout`)
2. when we got data from `socket.recv`, we check it immediately if we have received a valid JSON-format string. We return it immediately if it's valid JSON, otherwise make another `socket.recv`

After these changes, the `--init-db` command is much faster, here is my comparison:

```
IPC: 10000 blocks cost 108.00932908058167 seconds
RPC: 10000 blocks cost 124.78162384033203 seconds
```
IPC is a little bit faster than RPC.

Also note the timeout setting of socket is actually not affect the speed, since we almost always got correct response in time.

You can see the code changes from this PR, and which is base on an old commit(the one before the pool version), and to see if the new speed is good enough. Since I'm not a python expert, I'm not sure if there is any issues in the new code.

Another question: if the speed is good enough, do we still need to support level-db: <https://github.com/ConsenSys/mythril/issues/15>