### PR TITLE
explicitly satisfy rlp dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+rlp<1.0.0
 ethereum>=2.3.0
 ZODB>=5.3.0
 z3-solver>=4.5


### PR DESCRIPTION
fixes #144 

eth-tester depends on a lower version of rlp than was implicitly pulled in.