### PR TITLE
[WIP] Moves testing to tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,17 +10,26 @@ jobs:
       - checkout:
           path: /home/mythril
 
-      # Uncomment, for local testing with circleci command, as it ignores
-      # path param in checkout command, and this symlink compenstates for that.
-      # - run: ln -s /root/project /home/mythril
-
       - run:
           name: Installing mythril tools
           command: cd /home && ./install-mythril-tools.sh laser-ethereum
 
+#      - run:
+#          name: Install pyenv
+#          command: >
+#            curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+#            && export PATH="/root/.pyenv/bin:$PATH"
+#            && echo "export PATH=\"/root/.pyenv/bin:$PATH\"" >> ~/.bash_profile
+#            && echo "eval \"$(pyenv init -)\"" >> ~/.bash_profile
+#            && echo "eval \"$(pyenv virtualenv-init -)\"" >> ~/.bash_profile
+#
+#      - run:
+#          name: Install pythons
+#          command: pyenv install 3.6.5 && pyenv install 3.5.5
+
       - run:
-          name: Install dependencies, in case any are missing in Docker image
-          command: pip3 install -r /home/mythril/requirements.txt
+          name: Install tox
+          command: pip3 install tox
 
       - run:
           background: true
@@ -29,17 +38,16 @@ jobs:
 
       - run:
           name: Unit-testing
-          command: cd /home/mythril && ./all_tests.sh
+          command: cd /home/mythril && tox
+          environment:
+            LC_ALL: C.UTF-8
+            LANG: C.UTF-8
 
       - store_test_results:
-          path: /tmp/test-reports
+          path: /home/mythril/.tox/output
 
       - store_artifacts:
-          path: /tmp/test-reports
-
-      - run:
-          name: Ensuring that setup script is functional
-          command: cd /home/mythril && python3 setup.py install
+          path: /home/mythril/.tox/output
 
   deploy:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,119 @@
 .DS_Store
-.python-version
-__pycache__
-*.pyc
 *.asm
 mythril.egg-info
-build
-dist
+laser*
+lol*
+.idea
+coverage_html_report/
+tests/testdata/outputs_current/
+tests/mythril_dir/signatures.json
+
 *.rst
 *.lock
 !Pipfile.lock
 *.svg
-laser*
-lol*
-.idea*
-coverage_html_report/
+
+# Created by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
 .coverage
-.pytest_cache
-tests/testdata/outputs_current/
-tests/mythril_dir/signatures.json
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+
+# End of https://www.gitignore.io/api/python

--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ yapf = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.6"
+python_version = ">=3.5"
 
 [pipenv]
 allow_prereleases = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py36
+
+[testenv]
+deps=pipenv
+whitelist_externals = mkdir
+commands=
+    pipenv install --dev --ignore-pipfile
+    mkdir -p {toxworkdir}/log/{envname}
+    pipenv run py.test --junitxml={toxworkdir}/output/pytest/junit-{envname}.xml {posargs}


### PR DESCRIPTION
If we switch the testing program to tox we can automatically check the program against several versions of python. Eventually we could use pyenv to install several python versions in the testing environment.