### PR TITLE
Define version for rlp

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ eth-tester = "*"
 laser-ethereum = ">=0.5.20"
 "jinja2" = "*"
 attrs = ">=17.0.0"
-
+rlp = "<1.0.0"
 [dev-packages]
 pylint = "*"
 yapf = "*"

--- a/setup.py
+++ b/setup.py
@@ -322,7 +322,8 @@ setup(
         'eth-tester>=0.1.0b21',
         'coverage',
         'jinja2',
-        'attrs'
+        'attrs',
+        'rlp<1.0.0'
     ],
 
     python_requires='>=3.5',


### PR DESCRIPTION
It seems that the pip package does not include a version requirement for rlp, this causes fresh installs to be invalid. This pr adds a version definition for the rlp package