### PR TITLE
Change ints to bitvec

### DIFF
--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -62,6 +62,12 @@ def _check_integer_overflow(statespace, state, node):
     if not (type(op0) in allowed_types and type(op1) in allowed_types):
         return issues
 
+    # Change ints to BitVec
+    if type(op0) is int:
+        op0 = BitVecVal(op0, 256)
+    if type(op1) is int:
+        op1 = BitVecVal(op1, 256)
+
     # Formulate expression
     if instruction['opcode'] == "ADD":
         expr = op0 + op1


### PR DESCRIPTION
@maurelian found that while analyzing https://github.com/aragon/aragon-apps/blob/master/apps/voting/contracts/Voting.sol. Mythril would fail:
<img width="125" alt="image" src="https://user-images.githubusercontent.com/8710366/39381233-c19a496a-4a61-11e8-96bd-b3c1d87d36f7.png">

This happened because ULT(a, b) fails if both a and b are an int. The contract contains a situation where both op0 and op1 are ints, so expr is also an int (which triggered the problem).

This pr fixes the problem by putting op0 and op1 in bitvecs if they are ints