### PR TITLE
[wip] Integer false positive detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
       # Uncomment, for local testing with circleci command, as it ignores
       # path param in checkout command, and this symlink compenstates for that.
-      - run: ln -s /root/project /home/mythril
+      # - run: ln -s /root/project /home/mythril
 
       - run:
           name: Installing mythril tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
       # Uncomment, for local testing with circleci command, as it ignores
       # path param in checkout command, and this symlink compenstates for that.
-      # - run: ln -s /root/project /home/mythril
+      - run: ln -s /root/project /home/mythril
 
       - run:
           name: Installing mythril tools

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -82,7 +82,7 @@ def _check_integer_overflow(statespace, state, node):
         logging.debug("[INTEGER_OVERFLOW] no model found")
         return issues
 
-    if instruction['opcode'] != "MUL" and not _verify_integer_overflow(statespace, node, expr, state, model, constraint, op0, op1) :
+    if not _verify_integer_overflow(statespace, node, expr, state, model, constraint, op0, op1) :
         return issues
 
     # Build issue

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -284,3 +284,22 @@ def _search_children(statespace, node, expression, constraint=[], index=0, depth
         results += _search_children(statespace, child, expression, depth=depth + 1, max_depth=max_depth)
 
     return results
+
+
+def _check_requires(state, node, statespace, constraint):
+    """Checks if usage of overflowed statement results in a revert statement"""
+    instruction = state.get_current_instruction()
+    if instruction['opcode'] != 'JUMPI':
+        return False
+
+    children = \
+        [
+            statespace.nodes[edge.node_to]
+            for edge in statespace.edges
+            if edge.node_from == node.uid and _try_constraints(node.constraints, [constraint])
+        ]
+    for child in children:
+        opcodes = [s.get_current_instruction()['opcode'] for s in child.states]
+        if "REVERT" in opcodes:
+            return True
+    return False

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -299,10 +299,14 @@ def _check_requires(state, node, statespace, constraint):
     children = [
             statespace.nodes[edge.node_to]
             for edge in statespace.edges
-            if edge.node_from == node.uid and _try_constraints(statespace.nodes[edge.node_to].constraints, constraint) is not None
+            if edge.node_from == node.uid
         ]
+
     for child in children:
         opcodes = [s.get_current_instruction()['opcode'] for s in child.states]
         if "REVERT" in opcodes or "ASSERT_FAIL" in opcodes:
             return True
+    # I added the following case, bc of false positives if the max depth is not high enough
+    if len(children) == 0:
+        return True
     return False

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -30,7 +30,7 @@ def execute(statespace):
 
         for state in node.states:
             logging.debug("Checking for integer underflow")
-            # issues += _check_integer_underflow(statespace, state, node)
+            issues += _check_integer_underflow(statespace, state, node)
             logging.debug("Checking for integer overflow")
             issues += _check_integer_overflow(statespace, state, node)
 

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -82,7 +82,7 @@ def _check_integer_overflow(statespace, state, node):
         logging.debug("[INTEGER_OVERFLOW] no model found")
         return issues
 
-    if not _verify_integer_overflow(statespace, node, expr, state, model, constraint, op0, op1):
+    if instruction['opcode'] != "MUL" and not _verify_integer_overflow(statespace, node, expr, state, model, constraint, op0, op1) :
         return issues
 
     # Build issue
@@ -277,12 +277,13 @@ def _search_children(statespace, node, expression, constraint=[], index=0, depth
                 continue
             results += element
 
-            # Recursively search children
+    # Recursively search children
     children = \
         [
             statespace.nodes[edge.node_to]
             for edge in statespace.edges
-            if edge.node_from == node.uid and _try_constraints(statespace.nodes[edge.node_to].constraints, constraint) is not None
+            if edge.node_from == node.uid
+            and _try_constraints(statespace.nodes[edge.node_to].constraints, constraint) is not None
         ]
 
     for child in children:


### PR DESCRIPTION
I added two things to limit false positives.

 _check_requires(state, node, statespace, constraint) is now used to check if a potentially interesting jumpi statement isn't part of a requires statement by checking if one of its children has a revert/assert_fail instruction.

The second part was the addition of constraint checking while searching children for usage of a tainted variable. Only reachable children with the exploitation constraint will be checked

Fixes #159 
