### PR TITLE
fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:rolling
 COPY . .
 
 RUN apt-get update \
-  && apt-get install -y software-properties-common python-software-properties \
+  && apt-get install -y software-properties-common \
   && add-apt-repository -y ppa:ethereum/ethereum \
   && apt-get update \
   && apt-get install -y solc \


### PR DESCRIPTION
Apparently software-properties-common now provides for python-software-properties, which is deprecated.