### PR TITLE
Bugfix reporting non solidity projects

### DIFF
--- a/mythril/mythril.py
+++ b/mythril/mythril.py
@@ -327,7 +327,7 @@ class Mythril(object):
                 for issue in issues:
                     issue.add_code_info(contract)
 
-                all_issues += issues
+            all_issues += issues
 
         # Finally, output the results
         report = Report(verbose_report)


### PR DESCRIPTION
Issues for non SolidityContracts were ignored in the new cli module due to an indentation error. Fixes #193 