### PR TITLE
Fixes setup.py to include templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -330,7 +330,11 @@ setup(
 
     extras_require={
     },
-
+    
+    package_data={
+        'mythril.analysis': ['templates/*']
+    },
+    
     include_package_data=True,
 
     scripts=['myth'],


### PR DESCRIPTION
Templates were not being included in the setuptools-bundled version of mythril. This should resolve the problem.