### PR TITLE
bugfix: Change regex 

### DIFF
--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -10,7 +10,7 @@ def add_signatures_from_file(file, sigs={}):
 
         code = f.read()
 
-    funcs = re.findall(r'function[\s]+(.*?\))', code, re.DOTALL)
+    funcs = re.findall(r'function[\s]+(\w+\([^\)]*\))', code, re.DOTALL)
 
     for f in funcs:
 


### PR DESCRIPTION
Fixes #231 
The previous regex thought situations like: "function x sample )" were functions. Now the regex is a little bit more defined, so it should not fail in these situations anymore.

It should not really matter that functions in comment descriptions are also caught with this regex (as they were also caught using the previous, and seems to have worked fine)