### PR TITLE
Correct bionic apt dependency hell...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,17 @@ FROM ubuntu:bionic
 COPY . /opt/mythril
 
 RUN apt-get update \
-  && apt-get install -y software-properties-common \
+  && apt-get install -y \
+     build-essential \
+     python-pip-whl=9.0.1-2 \
+     python3-pip=9.0.1-2 \
+     python3-setuptools \
+     software-properties-common \
   && add-apt-repository -y ppa:ethereum/ethereum \
   && apt-get update \
   && apt-get install -y \
      solc \
      libssl-dev \
-     python3-pip=9.0.1-2 \
      python3-dev \
      pandoc \
      git \


### PR DESCRIPTION
When docker tries to install ethereum it fails with this: 

```
The following packages have unmet dependencies:
 python3-pip : Depends: python-pip-whl (= 9.0.1-2) but 9.0.1-2.3~ubuntu1 is to be installed
               Recommends: build-essential but it is not going to be installed
               Recommends: python3-setuptools but it is not going to be installed
               Recommends: python3-wheel but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt-get update   && apt-get install -y software-properties-common   && add-apt-repository -y ppa:ethereum/ethereum   && apt-get update   && apt-get install -y solc  libssl-dev      python3-pip=9.0.1-2  python3-dev  pandoc  git && ln -s /usr/bin/python3 /usr/local/bin/python && cd /opt/mythril   && pip3 install -r requirements.txt   && python setup.py install' returned a non-zero code: 100
```

I think what's happened is  in the previous stage `installed software-properties` we broke the build. The change proposed is install `python-pip-whl` in the previous step.  


Installing ethereum wants a particular version of python3-pip but
and earlier step to install mythril may install a newer version of that. 