### PR TITLE
Feature: online signature hash lookup and signatures refactor

### DIFF
--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -1,9 +1,9 @@
 from mythril.ether import asm,util
-from mythril.support.signatures import Signatures
+from mythril.support.signatures import SignatureDb
 import logging
 
 
-class Disassembly:
+class Disassembly(object):
 
     def __init__(self, code):
         self.instruction_list = asm.disassemble(util.safe_decode(code))
@@ -12,7 +12,7 @@ class Disassembly:
         self.addr_to_func = {}
         self.bytecode = code
 
-        signatures = Signatures(enable_online_lookup=True)  # control if you want to have online sighash lookups
+        signatures = SignatureDb(enable_online_lookup=True)  # control if you want to have online sighash lookups
         try:
             signatures.open()  # open from default locations
         except FileNotFoundError:
@@ -30,7 +30,7 @@ class Disassembly:
                 func_names = signatures.get(func_hash)
                 if len(func_names) > 1:
                     # ambigious result
-                    func_name = "**ambiguous** %s"%func_names[0]  # return first hit but note that result was ambiguous
+                    func_name = "**ambiguous** %s" % func_names[0]  # return first hit but note that result was ambiguous
                 else:
                     # only one item
                     func_name = func_names[0]
@@ -46,5 +46,8 @@ class Disassembly:
             except:
                 continue
 
+        signatures.write()  # store resolved signatures (potentially resolved online)
+
     def get_easm(self):
+        # todo: tintinweb - print funcsig resolved data from self.addr_to_func?
         return asm.instruction_list_to_easm(self.instruction_list)

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -99,7 +99,7 @@ class SignatureDb(object):
             logging.debug("Signatures: file not found: %s" % path)
             raise FileNotFoundError("Missing function signature file. Resolving of function names disabled.")
 
-        self.signatures_file_lock = SimpleFileLock(self.signatures_file)  # lock file to prevent concurrency issues
+        self.signatures_file_lock = self.signatures_file_lock or SimpleFileLock(self.signatures_file)  # lock file to prevent concurrency issues
         self.signatures_file_lock.aquire()  # try to aquire it within the next 10s
 
         with open(path, 'r') as f:
@@ -110,7 +110,7 @@ class SignatureDb(object):
         # normalize it to {sighash:list(signatures,...)}
         for sighash, funcsig in sigs.items():
             if isinstance(funcsig, list):
-                self.signatures = sigs  # keep original todo: tintinweb - super hacky. make sure signatures.json is initially in correct format fixme
+                self.signatures = sigs
                 break  # already normalized
             self.signatures.setdefault(sighash, [])
             self.signatures[sighash].append(funcsig)
@@ -126,7 +126,7 @@ class SignatureDb(object):
         :return: self
         """
         path = path or self.signatures_file
-        self.signatures_file_lock = SimpleFileLock(path)  # lock file to prevent concurrency issues
+        self.signatures_file_lock = self.signatures_file_lock or SimpleFileLock(path)  # lock file to prevent concurrency issues
         self.signatures_file_lock.aquire()  # try to aquire it within the next 10s
 
         if sync and os.path.exists(path):

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -56,9 +56,9 @@ def add_signatures_from_file(file, sigs={}):
 
 class Signatures(object):
 
-    def __init__(self, enable_online_lookkup=True):
+    def __init__(self, enable_online_lookup=True):
         self.signatures = {}  # signatures in-mem cache
-        self.enable_online_lookup =enable_online_lookkup  # enable online funcsig resolving
+        self.enable_online_lookup =enable_online_lookup  # enable online funcsig resolving
 
     def open(self, path=None):
         if not path:
@@ -91,14 +91,17 @@ class Signatures(object):
         :return: list of function signatures
         """
         if not self.signatures.get(sighash) and self.enable_online_lookup:
-            self.signatures[sighash] = Signatures.lookup_online(sighash)  # might return multiple sigs
-        return self.signatures.get(sighash)
+            funcsigs = Signatures.lookup_online(sighash)  # might return multiple sigs
+            if funcsigs:
+                # only store if we get at least one result
+                self.signatures[sighash] = funcsigs
+        return self.signatures[sighash]  # raise keyerror
 
 
     @staticmethod
     def lookup_online(sighash):
         """
-        Lookup function signatures from 4bytes.directory.
+        Lookup function signatures from 4byte.directory.
         //tintinweb: the smart-contract-sanctuary project dumps contracts from etherscan.io and feeds them into
                      4bytes.directory.
                      https://github.com/tintinweb/smart-contract-sanctuary

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -1,7 +1,17 @@
 import re
+import os
+import logging
+import json
 from ethereum import utils
 
+try:
+    # load if available but do not fail
+    import ethereum_input_decoder
+except ImportError:
+    ethereum_input_decoder = None
 
+
+# TODO: tintinweb: move this and signature functionality from mythril.py to class Signatures to have one single interface.
 def add_signatures_from_file(file, sigs={}):
 
     funcs = []
@@ -42,3 +52,60 @@ def add_signatures_from_file(file, sigs={}):
             signature = re.sub(r'\s', '', signature)
 
             sigs["0x" + utils.sha3(signature)[:4].hex()] = signature
+
+
+class Signatures(object):
+
+    def __init__(self, enable_online_lookkup=True):
+        self.signatures = {}  # signatures in-mem cache
+        self.enable_online_lookup =enable_online_lookkup  # enable online funcsig resolving
+
+    def open(self, path=None):
+        if not path:
+            #  try default locations
+            try:
+                mythril_dir = os.environ['MYTHRIL_DIR']
+            except KeyError:
+                mythril_dir = os.path.join(os.path.expanduser('~'), ".mythril")
+            path = os.path.join(mythril_dir, 'signatures.json')
+
+        if not os.path.exists(path):
+            raise FileNotFoundError("Missing function signature file. Resolving of function names disabled.")
+
+        with open(path) as f:
+            sigs = json.load(f)
+
+        # normalize it to {sighash:list(signatures,...)}
+        for sighash,funcsig in sigs.items():
+            self.signatures.setdefault(sighash, [])
+            self.signatures[sighash].append(funcsig)
+
+        return self
+
+    def get(self, sighash):
+        """
+        get a function signature for a sighash
+        1) try local cache
+        2) try online lookup
+        :param sighash:
+        :return: list of function signatures
+        """
+        if not self.signatures.get(sighash) and self.enable_online_lookup:
+            self.signatures[sighash] = Signatures.lookup_online(sighash)  # might return multiple sigs
+        return self.signatures.get(sighash)
+
+
+    @staticmethod
+    def lookup_online(sighash):
+        """
+        Lookup function signatures from 4bytes.directory.
+        //tintinweb: the smart-contract-sanctuary project dumps contracts from etherscan.io and feeds them into
+                     4bytes.directory.
+                     https://github.com/tintinweb/smart-contract-sanctuary
+
+        :param s: function signature as hexstr
+        :return: a list of possible function signatures for this hash
+        """
+        if not ethereum_input_decoder:
+            return None
+        return list(ethereum_input_decoder.decoder.FourByteDirectory.lookup_signatures(sighash))

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -1,66 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""mythril.py: Function Signature Database
+"""
 import re
 import os
-import logging
 import json
+import time
+import pathlib
+import logging
 from ethereum import utils
 
+# todo: tintinweb - make this a normal requirement? (deps: eth-abi and requests, both already required by mythril)
 try:
     # load if available but do not fail
     import ethereum_input_decoder
+    from ethereum_input_decoder.decoder import FourByteDirectoryOnlineLookupError
 except ImportError:
+    # fake it :)
     ethereum_input_decoder = None
+    FourByteDirectoryOnlineLookupError = Exception
 
 
-# TODO: tintinweb: move this and signature functionality from mythril.py to class Signatures to have one single interface.
-def add_signatures_from_file(file, sigs={}):
+class SimpleFileLock(object):
+    # todo: replace with something more reliable. this is a quick shot on concurrency and might not work in all cases
 
-    funcs = []
+    def __init__(self, path):
+        self.path = path
+        self.lockfile = pathlib.Path("%s.lck" % path)
+        self.locked = False
 
-    with open(file, encoding="utf-8") as f:
+    def aquire(self, timeout=5):
+        if self.locked:
+            raise Exception("SimpleFileLock: lock already aquired")
 
-        code = f.read()
+        t_end = time.time()+timeout
+        while time.time() < t_end:
+            # try to aquire lock
+            try:
+                self.lockfile.touch(mode=0o0000, exist_ok=False)  # touch the lockfile
+                # lockfile does not exist. we have a lock now
+                self.locked = True
+                return
+            except FileExistsError as fee:
+                # check if lockfile date exceeds age and cleanup lock
+                if time.time() > self.lockfile.stat().st_mtime + 60 * 5:
+                    self.release(force=True)  # cleanup old lockfile > 5mins
 
-    funcs = re.findall(r'function[\s]+(\w+\([^\)]*\))', code, re.DOTALL)
+                time.sleep(0.5)  # busywait is evil
+                continue
 
-    for f in funcs:
+        raise Exception("SimpleFileLock: timeout hit. failed to aquire lock: %s"% (time.time()-self.lockfile.stat().st_mtime))
 
-        f = re.sub(r'[\n]', '', f)
+    def release(self, force=False):
+        if not force and not self.locked:
+            raise Exception("SimpleFileLock: aquire lock first")
 
-        m = re.search(r'^([A-Za-z0-9_]+)', f)
+        try:
+            self.lockfile.unlink()  # might throw if we force unlock and the file gets removed in the meantime. TOCTOU
+        except FileNotFoundError as fnfe:
+            logging.warning("SimpleFileLock: release(force=%s) on unavailable file. race? %r" % (force, fnfe))
 
-        if (m):
-
-            signature = m.group(1)
-
-            m = re.search(r'\((.*)\)', f)
-
-            _args = m.group(1).split(",")
-
-            types = []
-
-            for arg in _args:
-
-                _type = arg.lstrip().split(" ")[0]
-                if _type == "uint":
-                    _type = "uint256"
-
-                types.append(_type)
-
-            typelist = ",".join(types)
-            signature += "(" + typelist + ")"
-
-            signature = re.sub(r'\s', '', signature)
-
-            sigs["0x" + utils.sha3(signature)[:4].hex()] = signature
+        self.locked = False
 
 
-class Signatures(object):
+
+class SignatureDb(object):
 
     def __init__(self, enable_online_lookup=True):
+        """
+        Constr
+        :param enable_online_lookup: enable onlien signature hash lookup
+        """
         self.signatures = {}  # signatures in-mem cache
-        self.enable_online_lookup =enable_online_lookup  # enable online funcsig resolving
+        self.signatures_file = None
+        self.signatures_file_lock = None
+        self.enable_online_lookup = enable_online_lookup  # enable online funcsig resolving
+        self.online_lookup_miss = set()  # temporarily track misses from onlinedb to avoid requesting the same non-existent sighash multiple times
+        self.online_directory_unavailable_until = 0  # flag the online directory as unavailable for some time
 
     def open(self, path=None):
+        """
+        Open a function signature db from json file
+
+        :param path: specific path to signatures.json; default mythril location if not specified
+        :return: self
+        """
         if not path:
             #  try default locations
             try:
@@ -69,46 +93,152 @@ class Signatures(object):
                 mythril_dir = os.path.join(os.path.expanduser('~'), ".mythril")
             path = os.path.join(mythril_dir, 'signatures.json')
 
+        self.signatures_file = path  # store early to allow error handling to access the place we tried to load the file
+
         if not os.path.exists(path):
+            logging.debug("Signatures: file not found: %s" % path)
             raise FileNotFoundError("Missing function signature file. Resolving of function names disabled.")
 
-        with open(path) as f:
+        self.signatures_file_lock = SimpleFileLock(self.signatures_file)  # lock file to prevent concurrency issues
+        self.signatures_file_lock.aquire()  # try to aquire it within the next 10s
+
+        with open(path, 'r') as f:
             sigs = json.load(f)
 
+        self.signatures_file_lock.release()  # release lock
+
         # normalize it to {sighash:list(signatures,...)}
-        for sighash,funcsig in sigs.items():
+        for sighash, funcsig in sigs.items():
+            if isinstance(funcsig, list):
+                self.signatures = sigs  # keep original todo: tintinweb - super hacky. make sure signatures.json is initially in correct format fixme
+                break  # already normalized
             self.signatures.setdefault(sighash, [])
             self.signatures[sighash].append(funcsig)
 
         return self
 
-    def get(self, sighash):
+    def write(self, path=None, sync=True):
+        """
+        Write signatures database as json to file
+
+        :param path: specify path otherwise update the file that was loaded with open()
+        :param sync: lock signature file, load contents and merge it into memcached sighash db, then save it
+        :return: self
+        """
+        path = path or self.signatures_file
+        self.signatures_file_lock = SimpleFileLock(path)  # lock file to prevent concurrency issues
+        self.signatures_file_lock.aquire()  # try to aquire it within the next 10s
+
+        if sync and os.path.exists(path):
+            # reload and save if file exists
+            with open(path, 'r') as f:
+                sigs = json.load(f)
+
+            sigs.update(self.signatures)  # reload file and merge cached sigs into what we load from file
+            self.signatures = sigs
+
+        with open(path, 'w') as f:
+            json.dump(self.signatures, f)
+
+        self.signatures_file_lock.release()
+        return self
+
+    def get(self, sighash, timeout=2):
         """
         get a function signature for a sighash
         1) try local cache
-        2) try online lookup
-        :param sighash:
-        :return: list of function signatures
+        2) try online lookup (if enabled; if not flagged as unavailable)
+        :param sighash: function signature hash as hexstr
+        :param timeout: online lookup timeout
+        :return: list of matching function signatures
         """
-        if not self.signatures.get(sighash) and self.enable_online_lookup:
-            funcsigs = Signatures.lookup_online(sighash)  # might return multiple sigs
-            if funcsigs:
-                # only store if we get at least one result
-                self.signatures[sighash] = funcsigs
+        if not sighash.startswith("0x"):
+            sighash = "0x%s" % sighash  # normalize sighash format
+
+        if self.enable_online_lookup and not self.signatures.get(sighash) and sighash not in self.online_lookup_miss and time.time() > self.online_directory_unavailable_until:
+            # online lookup enabled, and signature not in cache, sighash was not a miss earlier, and online directory not down
+            logging.debug("Signatures: performing online lookup for sighash %r" % sighash)
+            try:
+                funcsigs = SignatureDb.lookup_online(sighash, timeout=timeout)  # might return multiple sigs
+                if funcsigs:
+                    # only store if we get at least one result
+                    self.signatures[sighash] = funcsigs
+                else:
+                    # miss
+                    self.online_lookup_miss.add(sighash)
+            except FourByteDirectoryOnlineLookupError as fbdole:
+                self.online_directory_unavailable_until = time.time() + 2 * 60  # wait at least 2 mins to try again
+                logging.warning("online function signature lookup not available. will not try to lookup hash for the next 2 minutes. exception: %r" % fbdole)
         return self.signatures[sighash]  # raise keyerror
 
+    def __getitem__(self, item):
+        """
+        Provide dict interface Signatures()[sighash]
+        :param item: sighash
+        :return: list of matching signatures
+        """
+        return self.get(sighash=item)
+
+    def import_from_solidity_source(self, code):
+        """
+        Import Function Signatures from solidity source files
+        :param code: solidity source code
+        :return: self
+        """
+        self.signatures.update(SignatureDb.parse_function_signatures_from_solidity_source(code))
+        return self
 
     @staticmethod
-    def lookup_online(sighash):
+    def lookup_online(sighash, timeout=None, proxies=None):
         """
         Lookup function signatures from 4byte.directory.
         //tintinweb: the smart-contract-sanctuary project dumps contracts from etherscan.io and feeds them into
                      4bytes.directory.
                      https://github.com/tintinweb/smart-contract-sanctuary
 
-        :param s: function signature as hexstr
-        :return: a list of possible function signatures for this hash
+        :param sighash: function signature hash as hexstr
+        :param timeout: optional timeout for online lookup
+        :param proxies: optional proxy servers for online lookup
+        :return: a list of matching function signatures for this hash
         """
         if not ethereum_input_decoder:
             return None
-        return list(ethereum_input_decoder.decoder.FourByteDirectory.lookup_signatures(sighash))
+        return list(ethereum_input_decoder.decoder.FourByteDirectory.lookup_signatures(sighash,
+                                                                                       timeout=timeout,
+                                                                                       proxies=proxies))
+
+    @staticmethod
+    def parse_function_signatures_from_solidity_source(code):
+        """
+        Parse solidity sourcecode for function signatures and return the signature hash and function signature
+        :param code: solidity source code
+        :return: dictionary {sighash: function_signature}
+        """
+        sigs = {}
+
+        funcs = re.findall(r'function[\s]+(.*?\))', code, re.DOTALL)
+        for f in funcs:
+            f = re.sub(r'[\n]', '', f)
+            m = re.search(r'^([A-Za-z0-9_]+)', f)
+
+            if m:
+                signature = m.group(1)
+                m = re.search(r'\((.*)\)', f)
+                _args = m.group(1).split(",")
+                types = []
+
+                for arg in _args:
+                    _type = arg.lstrip().split(" ")[0]
+
+                    if _type == "uint":
+                        _type = "uint256"
+
+                    types.append(_type)
+
+                typelist = ",".join(types)
+                signature += "(" + typelist + ")"
+                signature = re.sub(r'\s', '', signature)
+                sigs["0x" + utils.sha3(signature)[:4].hex()] = signature
+
+        logging.debug("Signatures: parse soldiity found %d signatures" % len(sigs))
+        return sigs


### PR DESCRIPTION


Attempts to refactor the support/signatures modules to provide a `Signatures()` class which loads signatures from a specified path or from the default location. Optionally queries an online database to resolve function signatures.

The online database is https://4byte.directory (>65k sigs). I maintain a project at [smart-contract-sanctuary](https://github.com/tintinweb/smart-contract-sanctuary) that dumps contracts from etherscan.io and submits them to https://4byte.directory - this should even increase the coverage in the future.

As noted as a todo in `signatures.py` once this PR has been merged I'll submit another that moves the signature utility functionality to this class in order to have one interface to signatures.

**Dependencies:**
https://github.com/tintinweb/ethereum-input-decoder - (high level interface to eth_abi and access to 4byte.directory)

**Usage:**
```python
signatures = Signatures(enable_online_lookkup=True)  
try:
    signatures.open()  # open from default locations
except FileNotFoundError:
    logging.info("Missing function signature file. Resolving of function names from disabled.")

print(signatures.get(sighash))  # returns ["signature1","signature2"] or throws KeyError
```

cheers,
tin