### PR TITLE
Addin _ to codecopy function

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -515,7 +515,7 @@ class Instruction:
         return [global_state]
 
     @instruction
-    def codecopy(self, global_state):
+    def codecopy_(self, global_state):
         # FIXME: not implemented
         state = global_state.mstate
         start, s1, size = state.stack.pop(), state.stack.pop(), state.stack.pop()


### PR DESCRIPTION
Missing _ will not find the appropriate function when handling the codecopy instruction