### PR TITLE
Fixes a bug that causes the storage of the active account to act as a…

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -709,7 +709,11 @@ class Instruction:
         try:
             # Create a fresh copy of the account object before modifying storage
 
-            global_state.environment = deepcopy(global_state.environment)
+            for k in global_state.accounts:
+                if global_state.accounts[k] == global_state.environment.active_account:
+                    global_state.accounts[k] = deepcopy(global_state.accounts[k])
+                    global_state.environment.active_account = global_state.accounts[k]
+                    break
             
             global_state.environment.active_account.storage[index] = value
         except KeyError:
@@ -771,7 +775,7 @@ class Instruction:
         condi = condition if type(condition) == BoolRef else condition != 0
         if instr['opcode'] == "JUMPDEST":
             if (type(condi) == bool and condi) or (type(condi) == BoolRef and not is_false(simplify(condi))):
-                new_state = copy(global_state)
+                new_state = deepcopy(global_state)
                 new_state.mstate.pc = index
                 new_state.mstate.depth += 1
                 new_state.mstate.constraints.append(condi)

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -709,12 +709,8 @@ class Instruction:
         try:
             # Create a fresh copy of the account object before modifying storage
 
-            for k in global_state.accounts:
-                if global_state.accounts[k] == global_state.environment.active_account:
-                    global_state.accounts[k] = deepcopy(global_state.accounts[k])
-                    global_state.environment.active_account = global_state.accounts[k]
-                    break
-
+            global_state.environment = deepcopy(global_state.environment)
+            
             global_state.environment.active_account.storage[index] = value
         except KeyError:
             logging.debug("Error writing to storage: Invalid index")


### PR DESCRIPTION
… singleton

It is not enough to deepcopy the storage, as all copies of that global state will still point to the same environment, pointing to the same active account, pointing to the same now overwritten active account. I noticed this because after processing a STOP, the next instruction CALLVALUE of the alternative branch had the same storage content as stop.

One solution seems to be the proposed change actually deepcopying the entire environment, but it is also necessary to ensure that when branching mstate gets a new instance.