### PR TITLE
Bugfix/fix fallback name

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -767,25 +767,25 @@ class Instruction:
         instr = disassembly.instruction_list[index]
 
         # True case
-        condi = condition if type(condition) == BoolRef else condition != 0
+        condi = simplify(condition) if type(condition) == BoolRef else condition != 0
         if instr['opcode'] == "JUMPDEST":
-            if (type(condi) == bool and condi) or (type(condi) == BoolRef and not is_false(simplify(condi))):
+            if (type(condi) == bool and condi) or (type(condi) == BoolRef and not is_false(condi)):
                 new_state = copy(global_state)
                 new_state.mstate.pc = index
                 new_state.mstate.depth += 1
-                new_state.mstate.constraints.append(simplify(condi))
+                new_state.mstate.constraints.append(condi)
 
                 states.append(new_state)
             else:
                 logging.debug("Pruned unreachable states.")
 
         # False case
-        negated = Not(condition) if type(condition) == BoolRef else condition == 0
+        negated = simplify(Not(condition)) if type(condition) == BoolRef else condition == 0
 
-        if (type(negated) == bool and negated) or (type(negated) == BoolRef and not is_false(simplify(negated))):
+        if (type(negated) == bool and negated) or (type(negated) == BoolRef and not is_false(negated)):
             new_state = copy(global_state)
             new_state.mstate.depth += 1
-            new_state.mstate.constraints.append(simplify(negated))
+            new_state.mstate.constraints.append(negated)
             states.append(new_state)
         else:
             logging.debug("Pruned unreachable states.")

--- a/mythril/laser/ethereum/transaction.py
+++ b/mythril/laser/ethereum/transaction.py
@@ -50,7 +50,7 @@ class MessageCall:
                 evm.edges.append(Edge(open_world_state.node.uid, new_node.uid, edge_type=JumpType.Transaction, condition=None))
 
             global_state = GlobalState(open_world_state.accounts, environment, new_node)
-            global_state.environment.active_function_name = 'unnamed fallback'
+            global_state.environment.active_function_name = 'fallback'
             new_node.states.append(global_state)
 
             evm.work_list.append(global_state)

--- a/mythril/laser/ethereum/transaction.py
+++ b/mythril/laser/ethereum/transaction.py
@@ -50,7 +50,7 @@ class MessageCall:
                 evm.edges.append(Edge(open_world_state.node.uid, new_node.uid, edge_type=JumpType.Transaction, condition=None))
 
             global_state = GlobalState(open_world_state.accounts, environment, new_node)
-            global_state.environment.active_function_name = 'fallback()'
+            global_state.environment.active_function_name = 'fallback'
             new_node.states.append(global_state)
 
             evm.work_list.append(global_state)

--- a/mythril/laser/ethereum/transaction.py
+++ b/mythril/laser/ethereum/transaction.py
@@ -50,7 +50,7 @@ class MessageCall:
                 evm.edges.append(Edge(open_world_state.node.uid, new_node.uid, edge_type=JumpType.Transaction, condition=None))
 
             global_state = GlobalState(open_world_state.accounts, environment, new_node)
-            global_state.environment.active_function_name = 'fallback'
+            global_state.environment.active_function_name = 'unnamed fallback'
             new_node.states.append(global_state)
 
             evm.work_list.append(global_state)


### PR DESCRIPTION
remove simplifying bool in jumpi and also change fallback name.
As rocky mentioned in #390  someone using fallback as a function  it might cause a confusion. As of now i am thinking of using fallback instead of fallback() may do the work but i am not sure of it, so any suggestions?Another option as suggested by rocky is changing description of each issue for fallback seperately:- if thats the case then any suggestions on the display text for fallback.