### PR TITLE
Correct output when "-V -o json" option is given...

### DIFF
--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -84,7 +84,10 @@ def main():
     args = parser.parse_args()
 
     if args.version:
-        print("Mythril version {}".format(VERSION))
+        if args.outform == 'json':
+            print(json.dumps({'version_str': VERSION}))
+        else:
+            print("Mythril version {}".format(VERSION))
         sys.exit()
 
     # Parse cmdline args

--- a/tests/test_cli_opts.py
+++ b/tests/test_cli_opts.py
@@ -1,0 +1,25 @@
+from mythril.interfaces.cli import main
+import pytest
+import json
+
+import sys
+
+def test_version_opt(capsys):
+    # Check that "myth --version" returns a string with the word
+    # "version" in it
+    sys.argv = ['mythril', '--version']
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        main()
+    assert pytest_wrapped_e.type == SystemExit
+    captured = capsys.readouterr()
+    assert captured.out.find(' version ') >= 1
+
+    # Check that "myth --version -o json" returns a JSON object
+    sys.argv = ['mythril', '--version', '-o', 'json']
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        main()
+    assert pytest_wrapped_e.type == SystemExit
+    captured = capsys.readouterr()
+    d = json.loads(captured.out)
+    assert isinstance(d, dict)
+    assert d['version_str']


### PR DESCRIPTION
and start a unit test for options processing.