### PR TITLE
Fix codecopy for edge cases

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -547,10 +547,10 @@ class Instruction:
         bytecode = global_state.environment.active_account.code.bytecode
 
         for i in range(concrete_size):
-            try:
+            if 2 * (concrete_code_offset + i + 1) <= len(bytecode):
                 global_state.mstate.memory[concrete_memory_offset + i] =\
                     int(bytecode[2*(concrete_code_offset + i): 2*(concrete_code_offset + i + 1)], 16)
-            except IndexError:
+            else:
                 global_state.mstate.memory[concrete_memory_offset + i] = \
                     BitVec("code({})".format(global_state.environment.active_account.contract_name), 256)
 

--- a/mythril/leveldb/client.py
+++ b/mythril/leveldb/client.py
@@ -10,7 +10,7 @@ from mythril.leveldb.eth_db import ETH_DB
 from mythril.ether.ethcontract import ETHContract
 from mythril.exceptions import AddressNotFoundError
 
-# Per https://github.com/ethereum/go-ethereum/blob/master/core/database_util.go
+# Per https://github.com/ethereum/go-ethereum/blob/master/core/rawdb/schema.go
 # prefixes and suffixes for keys in geth
 header_prefix = b'h'         # header_prefix + num (uint64 big endian) + hash -> header
 body_prefix = b'b'           # body_prefix + num (uint64 big endian) + hash -> block body
@@ -23,7 +23,6 @@ head_header_key = b'LastBlock'  # head (latest) header hash
 address_prefix = b'AM'       # address_prefix + hash -> address
 # custom keys
 address_mapping_head_key = b'accountMapping'  # head (latest) number of indexed block
-head_header_key = b'LastBlock'  # head (latest) header hash
 
 
 def _format_block_number(number):


### PR DESCRIPTION
Interestingly codecopy seems to fail for some contracts like [0x88c1f00DF493673f72aa0481187A0Ff8c5ad0E14](https://etherscan.io/address/0x88c1f00DF493673f72aa0481187A0Ff8c5ad0E14#code) due to the fact that IndexError won't be thrown for slices which I realized recently(now). We may need to change in some other places too for this reason.

Also some leveldb cleanup