### PR TITLE
Implements concretized storage

### DIFF
--- a/mythril/laser/ethereum/state.py
+++ b/mythril/laser/ethereum/state.py
@@ -3,9 +3,36 @@ from copy import copy, deepcopy
 from enum import Enum
 from random import randint
 
+
 class CalldataType(Enum):
     CONCRETE = 1
     SYMBOLIC = 2
+
+
+class Storage:
+    """
+    Storage class represents the storage of an Account
+    """
+    def __init__(self, concrete=False):
+        """
+        Constructor for Storage
+        :param concrete: bool indicating whether to interpret uninitialized storage as concrete versus symbolic
+        """
+        self._storage = {}
+        self.concrete = concrete
+
+    def __getitem__(self, item):
+        try:
+            return self._storage[item]
+        except KeyError:
+            pass
+        if self.concrete:
+            return 0
+        self._storage[item] = BitVec("storage_" + str(item), 256)
+        return self._storage[item]
+
+    def __setitem__(self, key, value):
+        self._storage[key] = value
 
 
 class Account:
@@ -23,7 +50,7 @@ class Account:
         self.nonce = 0
         self.code = code
         self.balance = balance if balance else BitVec("balance", 256)
-        self.storage = {}
+        self.storage = Storage()
 
         # Metadata
         self.address = address

--- a/mythril/laser/ethereum/state.py
+++ b/mythril/laser/ethereum/state.py
@@ -39,18 +39,19 @@ class Account:
     """
     Account class representing ethereum accounts
     """
-    def __init__(self, address, code=None, contract_name="unknown", balance=None):
+    def __init__(self, address, code=None, contract_name="unknown", balance=None, concrete_storage=False):
         """
         Constructor for account
         :param address: Address of the account
         :param code: The contract code of the account
         :param contract_name: The name associated with the account
         :param balance: The balance for the account
+        :param concrete_storage: Interpret storage as concrete
         """
         self.nonce = 0
         self.code = code
         self.balance = balance if balance else BitVec("balance", 256)
-        self.storage = Storage()
+        self.storage = Storage(concrete_storage)
 
         # Metadata
         self.address = address
@@ -213,15 +214,16 @@ class WorldState:
         new_world_state.node = self.node
         return new_world_state
 
-    def create_account(self, balance=0, address=None):
+    def create_account(self, balance=0, address=None, concrete_storage=False):
         """
         Create non-contract account
         :param address: The account's address
         :param balance: Initial balance for the account
+        :param concrete_storage: Interpret account storage as concrete
         :return: The new account
         """
         address = address if address else self._generate_new_address()
-        new_account = Account(address, balance=balance)
+        new_account = Account(address, balance=balance, concrete_storage=concrete_storage)
         self._put_account(new_account)
         return new_account
 

--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -266,7 +266,7 @@ class LaserEVM:
         open_states = self.open_states[:]
         del self.open_states[:]
 
-        new_account = self.world_state.create_account(0)
+        new_account = self.world_state.create_account(0, concrete_storage=True)
 
         for open_world_state in open_states:
             transaction = ContractCreationTransaction(

--- a/mythril/laser/ethereum/transaction.py
+++ b/mythril/laser/ethereum/transaction.py
@@ -85,7 +85,7 @@ class ContractCreationTransaction:
 
         self.world_state = world_state
         # TODO: set correct balance for new account
-        self.callee_account = callee_account if callee_account else world_state.create_account(0)
+        self.callee_account = callee_account if callee_account else world_state.create_account(0, concrete_storage=True)
 
         self.caller = caller
         self.call_data = call_data


### PR DESCRIPTION
By default mythril will assume contract storage is still "symbolic". This means that if you SLOAD an unset storage slot it will assume its a symbol. This pr adds support for the concrete assumption (which is the case for multi-transactional analysis) in which case it will return 0 if an unset storage slot is queried.

Fixes #423