### PR TITLE
Deal with unknown input sizes

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -548,7 +548,7 @@ class Instruction:
         bytecode = global_state.environment.code.bytecode
 
         if concrete_size == 0 and isinstance(global_state.current_transaction, ContractCreationTransaction):
-            if concrete_code_offset == len(global_state.environment.code.bytecode) // 2:
+            if concrete_code_offset >= len(global_state.environment.code.bytecode) // 2:
                 global_state.mstate.mem_extend(concrete_memory_offset, 1)
                 global_state.mstate.memory[concrete_memory_offset] = \
                     BitVec("code({})".format(global_state.environment.active_account.contract_name), 256)

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -13,7 +13,7 @@ from mythril.laser.ethereum import util
 from mythril.laser.ethereum.call import get_call_parameters
 from mythril.laser.ethereum.state import GlobalState, MachineState, Environment, CalldataType
 import mythril.laser.ethereum.natives as natives
-from mythril.laser.ethereum.transaction import MessageCallTransaction, TransactionEndSignal, TransactionStartSignal
+from mythril.laser.ethereum.transaction import MessageCallTransaction, TransactionEndSignal, TransactionStartSignal, ContractCreationTransaction
 
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1
@@ -546,6 +546,13 @@ class Instruction:
             return [global_state]
 
         bytecode = global_state.environment.code.bytecode
+
+        if concrete_size == 0 and isinstance(global_state.current_transaction, ContractCreationTransaction):
+            if concrete_code_offset == len(global_state.environment.code.bytecode) // 2:
+                global_state.mstate.mem_extend(concrete_memory_offset, 1)
+                global_state.mstate.memory[concrete_memory_offset] = \
+                    BitVec("code({})".format(global_state.environment.active_account.contract_name), 256)
+                return [global_state]
 
         for i in range(concrete_size):
             if 2 * (concrete_code_offset + i + 1) <= len(bytecode):


### PR DESCRIPTION
fixes #440 

This is caused by solidity looking for parameters with unknown size. This pr will make sure that in this case the argument is interpreted as one 32byte symbol