### PR TITLE
Initialize account with contract name

### DIFF
--- a/mythril/analysis/symbolic.py
+++ b/mythril/analysis/symbolic.py
@@ -33,7 +33,7 @@ class SymExecWrapper:
                                   create_timeout=create_timeout)
 
         if isinstance(contract, SolidityContract):
-            self.laser.sym_exec(creation_code=contract.creation_code)
+            self.laser.sym_exec(creation_code=contract.creation_code, contract_name=contract.name)
         else:
             self.laser.sym_exec(address)
 

--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -61,7 +61,7 @@ class LaserEVM:
     def accounts(self):
         return self.world_state.accounts
 
-    def sym_exec(self, main_address=None, creation_code=None):
+    def sym_exec(self, main_address=None, creation_code=None, contract_name=None):
         logging.debug("Starting LASER execution")
         self.time = datetime.now()
 
@@ -70,7 +70,7 @@ class LaserEVM:
             execute_message_call(self, main_address)
         elif creation_code:
             logging.info("Starting contract creation transaction")
-            created_account = execute_contract_creation(self, creation_code)
+            created_account = execute_contract_creation(self, creation_code, contract_name)
             logging.info("Finished contract creation, found {} open states".format(len(self.open_states)))
             if len(self.open_states) == 0:
                 print("No contract was created during the execution of contract creation "

--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -26,12 +26,15 @@ def execute_message_call(laser_evm, callee_address):
     laser_evm.exec()
 
 
-def execute_contract_creation(laser_evm, contract_initialization_code):
+def execute_contract_creation(laser_evm, contract_initialization_code, contract_name=None):
     """ Executes a contract creation transaction from all open states"""
     open_states = laser_evm.open_states[:]
     del laser_evm.open_states[:]
 
     new_account = laser_evm.world_state.create_account(0, concrete_storage=True)
+    if contract_name:
+        new_account.contract_name = contract_name
+
 
     for open_world_state in open_states:
         transaction = ContractCreationTransaction(


### PR DESCRIPTION
During contract creation the account name of the created account was not set, with this pr it will be set to the name of the original contract in symbolic.py

closes #458 