### PR TITLE
Carry constraints with new transaction

### DIFF
--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -63,6 +63,7 @@ def _setup_global_state_for_execution(laser_evm, transaction):
     if transaction.world_state.node:
         laser_evm.edges.append(Edge(transaction.world_state.node.uid, new_node.uid, edge_type=JumpType.Transaction,
                                condition=None))
+        global_state.mstate.constraints = transaction.world_state.node.constraints
     global_state.node = new_node
     new_node.states.append(global_state)
     laser_evm.work_list.append(global_state)

--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -63,7 +63,10 @@ def _setup_global_state_for_execution(laser_evm, transaction):
     if transaction.world_state.node:
         laser_evm.edges.append(Edge(transaction.world_state.node.uid, new_node.uid, edge_type=JumpType.Transaction,
                                condition=None))
+
         global_state.mstate.constraints = transaction.world_state.node.constraints
+        new_node.constraints = global_state.mstate.constraints
+
     global_state.node = new_node
     new_node.states.append(global_state)
     laser_evm.work_list.append(global_state)


### PR DESCRIPTION
The constraints of the previous transaction where ignored. Which means that if we're examining a situation in transaction 2, then its assumed that the input for transaction 1 is unconstrained.

Which is of course not correct, this pr fixes that

Note for the future. Atm we have 2 locations where constraints are stored, make this unified