### PR TITLE
Put issue instructions in comments...

### DIFF
--- a/.github/ISSUE_TEMPLATE/analysis-module.md
+++ b/.github/ISSUE_TEMPLATE/analysis-module.md
@@ -4,34 +4,34 @@ about: Create an analysis module feature request
 
 ---
 
-Please remove any of the optional sections if they are not applicable.
+<!-- Please remove any of the optional sections if they are not applicable. -->
 
 ## Description
 
-Replace this text with a description of an vulnerability that should be
-detected by a Mythril analysis module.
+<!-- Replace this text with a description of an vulnerability that should be
+detected by a Mythril analysis module. -->
 
 ## Tests
 
-_This section is optional._
+<!-- This section is optional.
 
 Replace this text with suggestions on how to test the feature,
 if it is not obvious. This might require certain Solidity source,
 bytecode, or a Truffle project. You can also provide
-links to existing code.
+links to existing code. -->
 
 ## Implementation details
 
-_This section is optional._
+<!-- This section is optional.
 
 If you have thoughts about how to implement the analysis, feel free
-replace this text with that.
+replace this text with that. -->
 
 ## Links
 
-_This section is optional._
+<!-- This section is optional.
 
 Replace this text with any links describing the issue or pointing to resources
 that can help in implementing the analysis
 
-Thanks for helping!
+Thanks for helping! -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,25 +4,20 @@ about: Tell us about Mythril bugs to help us improve
 
 ---
 
-_Note: did you notice that there is now a template for requesting new features?_
+<!-- Note: did you notice that there is now a template for requesting new features?
 
-Please remove any of the optional sections if they are not applicable.
+Please remove any of the optional sections if they are not applicable. -->
 
 ## Description
 
-Replace this text with a clear and concise description of the bug.
+<!-- Replace this text with a clear and concise description of the bug. -->
 
 ## How to Reproduce
 
-Please show both the input you gave and the
-output you got in describing how to reproduce the bug:
+<!-- Please show both the input you gave and the
+output you got in describing how to reproduce the bug.
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-or give a complete console log with input and output
+For example:
 
 ```console
 $ myth <command-line-options>
@@ -34,22 +29,34 @@ Function name: ...
 $
 ```
 
+or perhaps:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
 If there is a Solidity source code, a truffle project, or bytecode
 that is involved, please provide that or links to it.
 
+-->
+
 ## Expected behavior
 
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 ## Screenshots
 
-_This section is optional._
+<!-- This section is optional.
 
 If applicable, add screenshots to help explain your problem.
 
+-->
+
 ## Environment
 
-_This section sometimes is optional but helpful to us._
+<!-- This section sometimes is optional but helpful to us.
 
 Please modify for your setup
 
@@ -58,10 +65,14 @@ Please modify for your setup
 - Python version: `python -V`
 - OS and Version: [e.g. Mac OS High Sierra]
 
+-->
+
 ## Additional Environment or Context
 
-_This section is optional._
+<!-- This section is optional.
 
 Add any other context about the problem here or special environment setup
 
 Thanks for helping!
+
+-->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,15 +6,16 @@ about: Tell us about a new feature that would make Mythril better
 
 ## Description
 
-Replace this text with a short description of the feature.
+<!-- Replace this text with a short description of the feature. -->
 
 ## Background
 
-Replace this text with any additional background for the
-feature, for example: user scenarios, or the value of the feature.
+<! -- Replace this text with any additional background for the
+feature, for example: user scenarios, or the value of the feature. -->
 
 ## Tests
-_This section is optional._
+
+<!-- This section is optional.
 
 Replace this text with suggestions on how to test the feature,
 if it is not obvious. This might require certain Solidity source,
@@ -22,3 +23,5 @@ bytecode, or a Truffle project. You can also provide
 links to existing code.
 
 Thanks for helping!
+
+-->


### PR DESCRIPTION
so users don't have to delete them. In bug-report.md, put possibly
the more likley thing to do at the top.

I know this seems silly, but some users (i.e. me) can spend a lot of time writing issues. So anything to simplify or improve things help a lot.