### PR TITLE
Fix issue 488: Broken CFG HTML output

### DIFF
--- a/mythril/analysis/templates/callgraph.html
+++ b/mythril/analysis/templates/callgraph.html
@@ -15,6 +15,9 @@
             color: #ffffff;
             font-size: 10px;
         }
+        html, body {
+          height: 95%;
+        }
     </style>
     {% else %}
     <style type="text/css">
@@ -26,6 +29,9 @@
             color: #000000;
             font-size: 10px;
             font-family: "courier new";
+        }
+        html, body {
+          height: 95%;
         }
     </style>
     {% endif %}

--- a/mythril/analysis/templates/callgraph.html
+++ b/mythril/analysis/templates/callgraph.html
@@ -8,6 +8,7 @@
     {% if not phrackify %}
     <style type="text/css">
         #mynetwork {
+          height: 100%;
             background-color: #232625;
         }
         body {
@@ -22,6 +23,7 @@
     {% else %}
     <style type="text/css">
         #mynetwork {
+            height: 100%;
             background-color: #ffffff;
         }
         body {

--- a/mythril/analysis/templates/callgraph.html
+++ b/mythril/analysis/templates/callgraph.html
@@ -38,7 +38,7 @@
 </head>
 <body>
 <p>{{ title }}</p>
-<p><div id="mynetwork"></div><br/></p>
+<div id="mynetwork"></div>
 <script type="text/javascript">
     var container = document.getElementById('mynetwork');
 


### PR DESCRIPTION
The problem here is that the added `<!DOCTYPE html>` makes the browser switch from [quirks mode](https://en.wikipedia.org/wiki/Quirks_mode) to standards mode. While that's what you usually want when declaring a doctype, it can break some layout logic.
In standards mode, elements like `html` and `body` don't occupy the whole page anymore but instead wrap around the smallest element. As only the network canvas had an explicit height defined (but it was calculated and fairly small), the body wrapped around the tiny canvas and all other relative heights took that as a reference point - making the whole layout small.

The solution is to explicitly assign a relative height to `html` and `body` tags and then scale up the UI elements relative to them. Also removed a redundant p-tag around the canvas `div`, as it's already a block element.