### PR TITLE
Fix Docker container crash with UnicodeEncodeError

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,6 @@ RUN apt-get update \
   && pip3 install -r requirements.txt \
   && python setup.py install
 
+ENV PYTHONIOENCODING=UTF-8
+
 ENTRYPOINT ["/usr/local/bin/myth"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY . /opt/mythril
 RUN apt-get update \
   && apt-get install -y \
      build-essential \
+     locales \
      python-pip-whl=9.0.1-2 \
      python3-pip=9.0.1-2 \
      python3-setuptools \
@@ -22,6 +23,9 @@ RUN apt-get update \
   && pip3 install -r requirements.txt \
   && python setup.py install
 
-ENV PYTHONIOENCODING=UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.en
+ENV LC_ALL en_US.UTF-8
 
 ENTRYPOINT ["/usr/local/bin/myth"]

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -221,7 +221,7 @@ def main():
                     'text': report.as_text(),
                     'markdown': report.as_markdown()
                 }
-                print(outputs[args.outform].encode('utf-8'))
+                print(outputs[args.outform])
 
         elif args.statespace_json:
 

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -221,7 +221,7 @@ def main():
                     'text': report.as_text(),
                     'markdown': report.as_markdown()
                 }
-                print(outputs[args.outform])
+                print(outputs[args.outform].encode('utf-8'))
 
         elif args.statespace_json:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ eth-keyfile>=0.5.1
 eth-keys>=0.2.0b3
 eth-rlp>=0.1.0
 eth-tester>=0.1.0b21
+eth-typing<2.0.0,>=1.3.0
 eth-utils>=1.0.1
 jinja2>=2.9
 mock


### PR DESCRIPTION
Fixes #479 

The report-generated output from the text and markdown functions returned text in UTF-8 encoding. The `print` function has an implicit encoding in ASCII. It tried to decode the bytes passed to it and crashed. The solution was to explicitly encode the input as UTF-8. This should also work when Mythril is run locally.

To make extra sure, I have set `PYTHONIOENCODING=UTF-8` in the Docker container's environment, which overrides the implicit print behaviour and encodes to UTF-8 by default.