### PR TITLE
Severity type "Information" -> "Informational" to match the others

### DIFF
--- a/mythril/analysis/modules/multiple_sends.py
+++ b/mythril/analysis/modules/multiple_sends.py
@@ -22,7 +22,7 @@ def execute(statespace):
             instruction = call.state.get_current_instruction()
             issue = Issue(node.contract_name, node.function_name, instruction['address'],
                           "Multiple Calls",
-                          "Information")
+                          "Informational")
 
             issue.description = \
                 "Multiple sends exist in one transaction, try to isolate each external call into its own transaction." \


### PR DESCRIPTION
Looks like "Informational" rather than "Information" seems to be what's used most often. Fixes #529 . 