### PR TITLE
fix mythril signature db throwing FileNotFoundError when using mythril as a library

### DIFF
--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -111,6 +111,8 @@ class SignatureDb(object):
         :return: self
         """
         path = path or self.signatures_file
+        directory = os.path.split(path)[0]
+
         if sync and os.path.exists(path):
             # reload and save if file exists
             with open(path, "r") as f:
@@ -122,7 +124,10 @@ class SignatureDb(object):
 
             sigs.update(self.signatures)  # reload file and merge cached sigs into what we load from file
             self.signatures = sigs
-        
+
+        if not os.path.exists(directory):
+            os.makedirs(directory)         # create folder structure if not existS
+
         if not os.path.exists(path):       # creates signatures.json file if it doesn't exist
             open(path, "w").close()
 

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -125,7 +125,7 @@ class SignatureDb(object):
             sigs.update(self.signatures)  # reload file and merge cached sigs into what we load from file
             self.signatures = sigs
 
-        if not os.path.exists(directory):
+        if directory and not os.path.exists(directory):
             os.makedirs(directory)         # create folder structure if not existS
 
         if not os.path.exists(path):       # creates signatures.json file if it doesn't exist


### PR DESCRIPTION
Hi,

mythril signature db does not check if the folder structure is set up (e.g.`~/.mythril/`) before calling `signaturedb.write()`. This PR checks if the folder exists and if not mkdirs it. Autocreating the folder is expected behavior as one can explicitly call `signature.write()` even if the signaturedb file does not yet exist.

only happens when using mythril as a library. otherwise mythril would initially setup the folder.

this was reported in https://github.com/tintinweb/ethereum-dasm/issues/10 

cheers,
tin