### PR TITLE
Add autoescaping to Jinja2 Report Environment

### DIFF
--- a/mythril/analysis/report.py
+++ b/mythril/analysis/report.py
@@ -45,7 +45,7 @@ class Issue:
 
 
 class Report:
-    environment = Environment(loader=PackageLoader('mythril.analysis'), trim_blocks=True)
+    environment = Environment(loader=PackageLoader('mythril.analysis'), trim_blocks=True, autoescape=True)
 
     def __init__(self, verbose=False):
         self.issues = {}


### PR DESCRIPTION
By default Jinja doesn't escape input provided to the Environment object, which is used to render data onto a template. While for text output this might not be too critical, many Markdown viewers allow embedding HTML, which leaves a potential attacker the option to embed JavaScript and do funny things.

While it's not super likely that an attacker will submit a well-crafted function name that's valid Solidity code or someone blindly piping their Mythril text output into an html/md file, we might want to be on the safe side here until the Jinja2 team enabled escaping by default.