### PR TITLE
Fix a couple of issues with the solc-args option

### DIFF
--- a/mythril/ether/util.py
+++ b/mythril/ether/util.py
@@ -18,10 +18,17 @@ def safe_decode(hex_encoded_string):
 
 def get_solc_json(file, solc_binary="solc", solc_args=None):
 
-    cmd = [solc_binary, "--combined-json", "bin,bin-runtime,srcmap,srcmap-runtime", '--allow-paths', "."]
+    cmd = [solc_binary, "--combined-json", "bin,bin-runtime,srcmap,srcmap-runtime"]
 
     if solc_args:
-        cmd.extend(solc_args.split(" "))
+        cmd.extend(solc_args.split())
+
+    if not "--allow-paths" in cmd:
+        cmd.extend(["--allow-paths", "."])
+    else:
+        for i, arg in enumerate(cmd):
+            if arg == "--allow-paths":
+                cmd[i + 1] += ",."
 
     cmd.append(file)
 

--- a/mythril/mythril.py
+++ b/mythril/mythril.py
@@ -317,7 +317,7 @@ class Mythril(object):
 
             try:
                 # import signatures from solidity source
-                self.sigs.import_from_solidity_source(file)
+                self.sigs.import_from_solidity_source(file, solc_binary=self.solc_binary, solc_args=self.solc_args)
                 # Save updated function signatures
                 self.sigs.write()  # dump signatures to disk (previously opened file or default location)
 

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -183,7 +183,7 @@ class SignatureDb(object):
         :param file_path: solidity source code file path
         :return: self
         """
-        self.signatures.update(SignatureDb.get_sigs_from_file(file_path, solc_binary, solc_args))
+        self.signatures.update(SignatureDb.get_sigs_from_file(file_path, solc_binary=solc_binary, solc_args=solc_args))
         return self
 
     @staticmethod
@@ -214,7 +214,7 @@ class SignatureDb(object):
         sigs = {}
         cmd = [solc_binary, "--hashes", file_name]
         if solc_args:
-            cmd.extend([i for i in solc_args.split(" ") if i != ""])
+            cmd.extend(solc_args.split())
         try:
             p = Popen(cmd, stdout=PIPE, stderr=PIPE)
             stdout, stderr = p.communicate()

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -177,13 +177,13 @@ class SignatureDb(object):
         """
         return self.get(sighash=item)
 
-    def import_from_solidity_source(self, file_path):
+    def import_from_solidity_source(self, file_path, solc_binary="solc", solc_args=None):
         """
         Import Function Signatures from solidity source files
         :param file_path: solidity source code file path
         :return: self
         """
-        self.signatures.update(SignatureDb.get_sigs_from_file(file_path))
+        self.signatures.update(SignatureDb.get_sigs_from_file(file_path, solc_binary, solc_args))
         return self
 
     @staticmethod
@@ -206,13 +206,15 @@ class SignatureDb(object):
                                                                                        proxies=proxies))
 
     @staticmethod
-    def get_sigs_from_file(file_name):
+    def get_sigs_from_file(file_name, solc_binary="solc", solc_args=None):
         """
         :param file_name: accepts a filename
         :return: their signature mappings
         """
         sigs = {}
-        cmd = ["solc", "--hashes", file_name]
+        cmd = [solc_binary, "--hashes", file_name]
+        if solc_args:
+            cmd.extend([i for i in solc_args.split(" ") if i != ""])
         try:
             p = Popen(cmd, stdout=PIPE, stderr=PIPE)
             stdout, stderr = p.communicate()


### PR DESCRIPTION
Now your can run it against a truffle project with the appropriate options.

To test it, create a new truffle project with some dependencies to openzeppelin and run:
```
$ myth --solc-args "openzeppelin-solidity=/Users/max/work/ponycontract/node_modules/openzeppelin-solidity --allow-paths /Users/max/work/ponycontract/node_modules/openzeppelin-solidity" \
-x contracts/ponycontract.sol
```

Previously it was failing due to the `import_from_solidity_source` method that was ignoring the `solc-args` and then it was failing due to multiple `--allow-paths` args provided to `solc`.

Note: I'm not proud of the argument cleanup function, I tried to find some utilities in the python library but didn't find any.