### PR TITLE
Fix mutable args

### DIFF
--- a/mythril/analysis/modules/external_calls.py
+++ b/mythril/analysis/modules/external_calls.py
@@ -16,8 +16,9 @@ Check for call.value()() to external addresses
 MAX_SEARCH_DEPTH = 64
 
 
-def search_children(statespace, node, start_index=0, depth=0, results=[]):
-
+def search_children(statespace, node, start_index=0, depth=0, results=None):
+    if results is None:
+        results = []
     logging.debug("SEARCHING NODE %d", node.uid)
 
     if depth < MAX_SEARCH_DEPTH:

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -214,7 +214,7 @@ def _check_sstore(state, taint_result):
     return taint_result.check(state, -2)
 
 
-def _search_children(statespace, node, expression, taint_result=None, constraint=[], index=0, depth=0, max_depth=64):
+def _search_children(statespace, node, expression, taint_result=None, constraint=None, index=0, depth=0, max_depth=64):
     """
     Checks the statespace for children states, with JUMPI or SSTORE instuctions,
     for dependency on expression
@@ -227,6 +227,9 @@ def _search_children(statespace, node, expression, taint_result=None, constraint
     :param max_depth: Max depth to explore
     :return: List of states that match the opcodes and are dependent on expression
     """
+    if constraint is None:
+        constraint = []
+
     logging.debug("SEARCHING NODE for usage of an overflowed variable %d", node.uid)
 
     if taint_result is None:

--- a/mythril/ether/asm.py
+++ b/mythril/ether/asm.py
@@ -42,9 +42,7 @@ def easm_to_instruction_list(easm):
             # Invalid code line
             continue
 
-        instruction = {}
-
-        instruction['opcode'] = m.group(1)
+        instruction = {'opcode': m.group(1)}
 
         if m.group(2):
             instruction['argument'] = m.group(2)[2:]
@@ -101,9 +99,7 @@ def disassemble(bytecode):
 
     while addr < length:
 
-        instruction = {}
-
-        instruction['address'] = addr
+        instruction = {'address': addr}
 
         try:
             if (sys.version_info > (3, 0)):

--- a/mythril/laser/ethereum/state.py
+++ b/mythril/laser/ethereum/state.py
@@ -135,8 +135,10 @@ class MachineStack(list):
     """
     STACK_LIMIT = 1024
 
-    def __init__(self, default_list=[]):
+    def __init__(self, default_list=None):
         super(MachineStack, self).__init__(default_list)
+        if default_list is None:
+            default_list = []
 
     def append(self, element):
         """

--- a/mythril/laser/ethereum/state.py
+++ b/mythril/laser/ethereum/state.py
@@ -136,9 +136,9 @@ class MachineStack(list):
     STACK_LIMIT = 1024
 
     def __init__(self, default_list=None):
-        super(MachineStack, self).__init__(default_list)
         if default_list is None:
             default_list = []
+        super(MachineStack, self).__init__(default_list)
 
     def append(self, element):
         """

--- a/mythril/laser/ethereum/taint_analysis.py
+++ b/mythril/laser/ethereum/taint_analysis.py
@@ -82,7 +82,7 @@ class TaintRunner:
     """
 
     @staticmethod
-    def execute(statespace, node, state, initial_stack=[]):
+    def execute(statespace, node, state, initial_stack=None):
         """
         Runs taint analysis on the statespace
         :param statespace: symbolic statespace to run taint analysis on
@@ -91,6 +91,8 @@ class TaintRunner:
         :param stack_indexes: stack indexes to introduce taint
         :return: TaintResult object containing analysis results
         """
+        if initial_stack is None:
+            initial_stack = []
         result = TaintResult()
         transaction_stack_length = len(node.states[0].transaction_stack)
         # Build initial current_node

--- a/mythril/mythril.py
+++ b/mythril/mythril.py
@@ -382,7 +382,9 @@ class Mythril(object):
 
         return report
 
-    def get_state_variable_from_storage(self, address, params=[]):
+    def get_state_variable_from_storage(self, address, params=None):
+        if params is None:
+            params = []
         (position, length, mappings) = (0, 1, [])
         try:
             if params[0] == "mapping":


### PR DESCRIPTION
This fixes a common Python gotcha. Default arguments are evaluated only once when the function is *defined*. Mutable default arguments thus are declared once in memory and referenced over and over again when used. A simple example:

```python
In [9]: def append_to_list(value, l=[]):
   ...:     l.append(value)
   ...:     return l
   ...: 

In [10]: append_to_list(42)
Out[10]: [42]

In [11]: append_to_list(1337)
Out[11]: [42, 1337]
```

On the second function call you might have expected `[1337]` to return, however what you get is the mutable default type's appended version. This might introduce some subtle bugs where e.g. more states are in a list (and evaluated) than there actually are. The solution is to simply define a new list at runtime if no argument is given.