### PR TITLE
Change regex to limit to correct pattern

### DIFF
--- a/mythril/ether/ethcontract.py
+++ b/mythril/ether/ethcontract.py
@@ -12,8 +12,8 @@ class ETHContract(persistent.Persistent):
         # Dynamic contract addresses of the format __[contract-name]_____________ are replaced with a generic address
         # Apply this for creation_code & code
 
-        creation_code = re.sub(r'(_+.*_+)', 'aa' * 20, creation_code)
-        code = re.sub(r'(_+.*_+)', 'aa' * 20, code)
+        creation_code = re.sub(r'(_{2}.{38})', 'aa' * 20, creation_code)
+        code = re.sub(r'(_{2}.{38})', 'aa' * 20, code)
 
         self.creation_code = creation_code
         self.name = name


### PR DESCRIPTION
This causes contracts with multiple links to be modified incorrectly.
If there were multiple links then it would see them as one and also remove the bytecode in between.

Fixes #568

However, no reentrancy is reported