### PR TITLE
Add SMT abstraction

### DIFF
--- a/mythril/analysis/callgraph.py
+++ b/mythril/analysis/callgraph.py
@@ -2,7 +2,7 @@ import re
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from mythril.laser.ethereum.svm import NodeFlags
-import z3
+from mythril.laser.ethereum.smt_wrapper import simplify, SimplificationError
 
 default_opts = {
     'autoResize': True,
@@ -127,8 +127,8 @@ def extract_edges(statespace):
             label = ""
         else:
             try:
-                label = str(z3.simplify(edge.condition)).replace("\n", "")
-            except z3.Z3Exception:
+                label = str(simplify(edge.condition)).replace("\n", "")
+            except SimplificationError:
                 label = str(edge.condition).replace("\n", "")
 
         label = re.sub(r'([^_])([\d]{2}\d+)', lambda m: m.group(1) + hex(int(m.group(2))), label)

--- a/mythril/analysis/modules/delegatecall.py
+++ b/mythril/analysis/modules/delegatecall.py
@@ -2,6 +2,7 @@ import re
 from mythril.analysis.swc_data import DELEGATECALL_TO_UNTRUSTED_CONTRACT
 from mythril.analysis.ops import get_variable, VarType
 from mythril.analysis.report import Issue
+from mythril.laser.ethereum.smt_wrapper import formula_to_string
 import logging
 
 
@@ -41,7 +42,7 @@ def execute(statespace):
 
 
 def _concrete_call(call, state, address, meminstart):
-    if not re.search(r'calldata.*_0', str(state.mstate.memory[meminstart.val])):
+    if not re.search(r'calldata.*_0', formula_to_string(state.mstate.memory[meminstart.val])):
         return []
 
     issue = Issue(contract=call.node.contract_name, function=call.node.function_name, address=address,
@@ -68,7 +69,7 @@ def _symbolic_call(call, state, address, statespace):
             "This contract delegates execution to a contract address obtained from calldata. "
 
     else:
-        m = re.search(r'storage_([a-z0-9_&^]+)', str(call.to))
+        m = re.search(r'storage_([a-z0-9_&^]+)', formula_to_string(call.to))
 
         if m:
             idx = m.group(1)

--- a/mythril/analysis/modules/dependence_on_predictable_vars.py
+++ b/mythril/analysis/modules/dependence_on_predictable_vars.py
@@ -120,8 +120,8 @@ def solve(call):
         model = solver.get_model(call.node.constraints)
         logging.debug("[DEPENDENCE_ON_PREDICTABLE_VARS] MODEL: " + str(model))
 
-        for d in model.decls():
-            logging.debug("[DEPENDENCE_ON_PREDICTABLE_VARS] main model: %s = 0x%x" % (d.name(), get_concrete_value(model[d])))
+        for (name, value) in model:
+            logging.debug("[DEPENDENCE_ON_PREDICTABLE_VARS] main model: %s = 0x%x" % (name, get_concrete_value(value)))
         return True
 
     except UnsatError:

--- a/mythril/analysis/modules/dependence_on_predictable_vars.py
+++ b/mythril/analysis/modules/dependence_on_predictable_vars.py
@@ -1,5 +1,4 @@
 import re
-from z3 import *
 from mythril.analysis.ops import VarType
 from mythril.analysis import solver
 from mythril.analysis.report import Issue

--- a/mythril/analysis/modules/dependence_on_predictable_vars.py
+++ b/mythril/analysis/modules/dependence_on_predictable_vars.py
@@ -4,6 +4,7 @@ from mythril.analysis.ops import VarType
 from mythril.analysis import solver
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import TIMESTAMP_DEPENDENCE, PREDICTABLE_VARS_DEPENDENCE
+from mythril.laser.ethereum.smt_wrapper import get_concrete_value
 from mythril.exceptions import UnsatError
 import logging
 
@@ -121,7 +122,7 @@ def solve(call):
         logging.debug("[DEPENDENCE_ON_PREDICTABLE_VARS] MODEL: " + str(model))
 
         for d in model.decls():
-            logging.debug("[DEPENDENCE_ON_PREDICTABLE_VARS] main model: %s = 0x%x" % (d.name(), model[d].as_long()))
+            logging.debug("[DEPENDENCE_ON_PREDICTABLE_VARS] main model: %s = 0x%x" % (d.name(), get_concrete_value(model[d])))
         return True
 
     except UnsatError:

--- a/mythril/analysis/modules/ether_send.py
+++ b/mythril/analysis/modules/ether_send.py
@@ -111,8 +111,8 @@ def execute(statespace):
                 try:
                     model = solver.get_model(node.constraints)
 
-                    for d in model.decls():
-                        logging.debug("[ETHER_SEND] main model: %s = 0x%x" % (d.name(), get_concrete_value(model[d])))
+                    for (name, value )in model:
+                        logging.debug("[ETHER_SEND] main model: %s = 0x%x" % (name, get_concrete_value(value)))
 
                     debug = "SOLVER OUTPUT:\n" + solver.pretty_print_model(model)
 

--- a/mythril/analysis/modules/ether_send.py
+++ b/mythril/analysis/modules/ether_send.py
@@ -2,7 +2,8 @@ from mythril.analysis.ops import *
 from mythril.analysis import solver
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNPROTECTED_ETHER_WITHDRAWAL
-from mythril.laser.ethereum.smt_wrapper import get_concrete_value
+from mythril.laser.ethereum.smt_wrapper import \
+    get_concrete_value, formula_to_string
 from mythril.exceptions import UnsatError
 import re
 import logging
@@ -41,16 +42,16 @@ def execute(statespace):
 
         description = "In the function `" + call.node.function_name + "` "
 
-        if re.search(r'caller', str(call.to)):
+        if re.search(r'caller', formula_to_string(call.to)):
             description += "a non-zero amount of Ether is sent to msg.sender.\n"
             interesting = True
 
-        elif re.search(r'calldata', str(call.to)):
+        elif re.search(r'calldata', formula_to_string(call.to)):
             description += "a non-zero amount of Ether is sent to an address taken from function arguments.\n"
             interesting = True
 
         else:
-            m = re.search(r'storage_([a-z0-9_&^]+)', str(call.to))
+            m = re.search(r'storage_([a-z0-9_&^]+)', formula_to_string(call.to))
 
             if m:
                 idx = m.group(1)
@@ -78,9 +79,9 @@ def execute(statespace):
 
                 constraint = node.constraints[index]
                 index += 1
-                logging.debug("[ETHER_SEND] Constraint: " + str(constraint))
+                logging.debug("[ETHER_SEND] Constraint: " + formula_to_string(constraint))
 
-                m = re.search(r'storage_([a-z0-9_&^]+)', str(constraint))
+                m = re.search(r'storage_([a-z0-9_&^]+)', formula_to_string(constraint))
 
                 if m:
 
@@ -98,7 +99,8 @@ def execute(statespace):
 
                 # CALLER may also be constrained to hardcoded address. I.e. 'caller' and some integer
 
-                elif re.search(r"caller", str(constraint)) and re.search(r'[0-9]{20}', str(constraint)):
+                elif re.search(r"caller", formula_to_string(constraint)) and \
+                     re.search(r'[0-9]{20}', formula_to_string(constraint)):
                     constrained = True
                     can_solve = False
                     break

--- a/mythril/analysis/modules/ether_send.py
+++ b/mythril/analysis/modules/ether_send.py
@@ -1,4 +1,3 @@
-from z3 import *
 from mythril.analysis.ops import *
 from mythril.analysis import solver
 from mythril.analysis.report import Issue

--- a/mythril/analysis/modules/ether_send.py
+++ b/mythril/analysis/modules/ether_send.py
@@ -3,6 +3,7 @@ from mythril.analysis.ops import *
 from mythril.analysis import solver
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNPROTECTED_ETHER_WITHDRAWAL
+from mythril.laser.ethereum.smt_wrapper import get_concrete_value
 from mythril.exceptions import UnsatError
 import re
 import logging
@@ -112,7 +113,7 @@ def execute(statespace):
                     model = solver.get_model(node.constraints)
 
                     for d in model.decls():
-                        logging.debug("[ETHER_SEND] main model: %s = 0x%x" % (d.name(), model[d].as_long()))
+                        logging.debug("[ETHER_SEND] main model: %s = 0x%x" % (d.name(), get_concrete_value(model[d])))
 
                     debug = "SOLVER OUTPUT:\n" + solver.pretty_print_model(model)
 

--- a/mythril/analysis/modules/external_calls.py
+++ b/mythril/analysis/modules/external_calls.py
@@ -1,4 +1,3 @@
-from z3 import *
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis import solver

--- a/mythril/analysis/modules/external_calls.py
+++ b/mythril/analysis/modules/external_calls.py
@@ -2,6 +2,7 @@ from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis import solver
 from mythril.analysis.swc_data import REENTRANCY
+from mythril.laser.ethereum.smt_wrapper import formula_to_string
 import re
 import logging
 
@@ -75,7 +76,7 @@ def execute(statespace):
 
                     user_supplied = True
                 else:
-                    m = re.search(r'storage_([a-z0-9_&^]+)', str(call.to))
+                    m = re.search(r'storage_([a-z0-9_&^]+)', formula_to_string(call.to))
 
                     if m:
                         idx = m.group(1)

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -5,7 +5,7 @@ from mythril.analysis.swc_data import INTEGER_OVERFLOW_AND_UNDERFLOW
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.taint_analysis import TaintRunner
 from mythril.laser.ethereum.smt_wrapper import \
-    Neq, Not, ULT, UGT, And, Or, is_bv, BitVecVal
+    Neq, Not, ULT, UGT, And, Or, is_bv, BitVecVal, formula_to_string
 import re
 import copy
 import logging
@@ -154,11 +154,13 @@ def _check_integer_underflow(statespace, state, node):
         # Pattern 2: (256*If(1 & storage_0 == 0, 1, 0)) - 1, this would underlow if storage_0 = 0
         if type(op0) == int and type(op1) == int:
             return []
-        if re.search(r'calldatasize_', str(op0)):
+        if re.search(r'calldatasize_', formula_to_string(op0)):
             return []
-        if re.search(r'256\*.*If\(1', str(op0), re.DOTALL) or re.search(r'256\*.*If\(1', str(op1), re.DOTALL):
+        if re.search(r'256\*.*If\(1', formula_to_string(op0), re.DOTALL) or \
+           re.search(r'256\*.*If\(1', formula_to_string(op1), re.DOTALL):
             return []
-        if re.search(r'32 \+.*calldata', str(op0), re.DOTALL) or re.search(r'32 \+.*calldata', str(op1), re.DOTALL):
+        if re.search(r'32 \+.*calldata', formula_to_string(op0), re.DOTALL) or \
+           re.search(r'32 \+.*calldata', formula_to_string(op1), re.DOTALL):
             return []
 
         logging.debug("[INTEGER_UNDERFLOW] Checking SUB {0}, {1} at address {2}".format(str(op0), str(op1),

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -38,6 +38,10 @@ def execute(statespace):
     return issues
 
 
+def _is_allowed_type(op) -> bool:
+    return isinstance(op, int) or is_bv(op)
+
+
 def _check_integer_overflow(statespace, state, node):
     """
     Checks for integer overflow
@@ -59,8 +63,7 @@ def _check_integer_overflow(statespace, state, node):
 
     # An integer overflow is possible if op0 + op1 or op0 * op1 > MAX_UINT
     # Do a type check
-    allowed_types = [int, BitVecRef, BitVecNumRef]
-    if not (type(op0) in allowed_types and type(op1) in allowed_types):
+    if not (_is_allowed_type(op0) and _is_allowed_type(op1)):
         return issues
 
     # Change ints to BitVec
@@ -159,9 +162,7 @@ def _check_integer_underflow(statespace, state, node):
 
         logging.debug("[INTEGER_UNDERFLOW] Checking SUB {0}, {1} at address {2}".format(str(op0), str(op1),
                                                                                         str(instruction['address'])))
-        allowed_types = [int, BitVecRef, BitVecNumRef]
-
-        if type(op0) in allowed_types and type(op1) in allowed_types:
+        if _is_allowed_type(op0) and _is_allowed_type(op1):
             constraints.append(UGT(op1, op0))
 
             try:

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -1,11 +1,11 @@
-from z3 import *
 from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import INTEGER_OVERFLOW_AND_UNDERFLOW
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.taint_analysis import TaintRunner
-from mythril.laser.ethereum.smt_wrapper import Neq
+from mythril.laser.ethereum.smt_wrapper import \
+    Neq, Not, ULT, UGT, And, Or, is_bv, BitVecVal
 import re
 import copy
 import logging

--- a/mythril/analysis/modules/integer.py
+++ b/mythril/analysis/modules/integer.py
@@ -5,6 +5,7 @@ from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import INTEGER_OVERFLOW_AND_UNDERFLOW
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.taint_analysis import TaintRunner
+from mythril.laser.ethereum.smt_wrapper import Neq
 import re
 import copy
 import logging
@@ -79,7 +80,7 @@ def _check_integer_overflow(statespace, state, node):
         expr = op1 * op0
 
     # Check satisfiable
-    constraint = Or(And(ULT(expr, op0), op1 != 0), And(ULT(expr, op1), op0 != 0))
+    constraint = Or(And(ULT(expr, op0), Neq(op1, 0)), And(ULT(expr, op1), Neq(op0, 0)))
     model = _try_constraints(node.constraints, [constraint])
 
     if model is None:

--- a/mythril/analysis/modules/suicide.py
+++ b/mythril/analysis/modules/suicide.py
@@ -2,6 +2,7 @@ from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNPROTECTED_SELFDESTRUCT
+from mythril.laser.ethereum.smt_wrapper import get_concrete_value
 from mythril.exceptions import UnsatError
 import logging
 
@@ -48,7 +49,7 @@ def _analyze_state(state, node):
     elif "calldata" in str(to):
         description += "The remaining Ether is sent to an address provided as a function argument.\n"
     elif type(to) == BitVecNumRef:
-        description += "The remaining Ether is sent to: " + hex(to.as_long()) + "\n"
+        description += "The remaining Ether is sent to: " + hex(get_concrete_value(to)) + "\n"
     else:
         description += "The remaining Ether is sent to: " + str(to) + "\n"
 

--- a/mythril/analysis/modules/suicide.py
+++ b/mythril/analysis/modules/suicide.py
@@ -1,3 +1,4 @@
+from z3 import is_bv_value
 from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
@@ -48,7 +49,7 @@ def _analyze_state(state, node):
         description += "The remaining Ether is sent to a stored address.\n"
     elif "calldata" in str(to):
         description += "The remaining Ether is sent to an address provided as a function argument.\n"
-    elif type(to) == BitVecNumRef:
+    elif is_bv_value(to):
         description += "The remaining Ether is sent to: " + hex(get_concrete_value(to)) + "\n"
     else:
         description += "The remaining Ether is sent to: " + str(to) + "\n"

--- a/mythril/analysis/modules/suicide.py
+++ b/mythril/analysis/modules/suicide.py
@@ -3,7 +3,7 @@ from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNPROTECTED_SELFDESTRUCT
-from mythril.laser.ethereum.smt_wrapper import get_concrete_value
+from mythril.laser.ethereum.smt_wrapper import get_concrete_value, Eq
 from mythril.exceptions import UnsatError
 import logging
 
@@ -58,8 +58,8 @@ def _analyze_state(state, node):
     if len(state.world_state.transaction_sequence) > 1:
         creator = state.world_state.transaction_sequence[0].caller
         for transaction in state.world_state.transaction_sequence[1:]:
-            not_creator_constraints.append(Not(Extract(159, 0, transaction.caller) == Extract(159, 0, creator)))
-            not_creator_constraints.append(Not(Extract(159, 0, transaction.caller) == 0))
+            not_creator_constraints.append(Not(Eq(Extract(159, 0, transaction.caller), Extract(159, 0, creator))))
+            not_creator_constraints.append(Not(Eq(Extract(159, 0, transaction.caller), 0)))
 
     try:
         model = solver.get_model(node.constraints + not_creator_constraints)

--- a/mythril/analysis/modules/suicide.py
+++ b/mythril/analysis/modules/suicide.py
@@ -1,9 +1,10 @@
-from z3 import is_bv_value
 from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNPROTECTED_SELFDESTRUCT
-from mythril.laser.ethereum.smt_wrapper import get_concrete_value, Eq
+from mythril.laser.ethereum.smt_wrapper import \
+    get_concrete_value, Eq, \
+    is_bv_value, Extract, Not
 from mythril.exceptions import UnsatError
 import logging
 

--- a/mythril/analysis/modules/transaction_order_dependence.py
+++ b/mythril/analysis/modules/transaction_order_dependence.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import copy
 
 from mythril.analysis import solver
 from mythril.analysis.ops import *

--- a/mythril/analysis/modules/transaction_order_dependence.py
+++ b/mythril/analysis/modules/transaction_order_dependence.py
@@ -6,6 +6,7 @@ from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import TX_ORDER_DEPENDENCE
+from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError
 from mythril.exceptions import UnsatError
 
 '''
@@ -113,7 +114,7 @@ def _get_influencing_sstores(statespace, interesting_storages):
         index, value = sstore_state.mstate.stack[-1], sstore_state.mstate.stack[-2]
         try:
             index = util.get_concrete_int(index)
-        except AttributeError:
+        except NotConcreteValueError:
             index = str(index)
         if "storage_{}".format(index) not in interesting_storages:
             continue

--- a/mythril/analysis/modules/transaction_order_dependence.py
+++ b/mythril/analysis/modules/transaction_order_dependence.py
@@ -7,7 +7,7 @@ from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import TX_ORDER_DEPENDENCE
 from mythril.laser.ethereum.smt_wrapper import \
-    NotConcreteValueError, Neq, simplify
+    NotConcreteValueError, Neq, simplify, formula_to_string
 from mythril.exceptions import UnsatError
 
 '''
@@ -68,7 +68,7 @@ def _get_storage_variable(storage, state):
     :param state: state to retrieve the variable from
     :return: z3 object representing storage
     """
-    index = int(re.search('[0-9]+', storage).group())
+    index = int(re.search('[0-9]+', formula_to_string(storage)).group())
     try:
         return state.environment.active_account.storage[index]
     except KeyError:

--- a/mythril/analysis/modules/transaction_order_dependence.py
+++ b/mythril/analysis/modules/transaction_order_dependence.py
@@ -83,7 +83,7 @@ def _can_change(constraints, variable):
     except UnsatError:
         return False
     try:
-        initial_value = int(str(model.eval(variable, model_completion=True)))
+        initial_value = int(str(model.get_value(variable, model_completion=True)))
         return _try_constraints(constraints, [Neq(variable, initial_value)]) is not None
     except AttributeError:
         return False

--- a/mythril/analysis/modules/transaction_order_dependence.py
+++ b/mythril/analysis/modules/transaction_order_dependence.py
@@ -6,7 +6,8 @@ from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import TX_ORDER_DEPENDENCE
-from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError, Neq
+from mythril.laser.ethereum.smt_wrapper import \
+    NotConcreteValueError, Neq, simplify
 from mythril.exceptions import UnsatError
 
 '''

--- a/mythril/analysis/modules/transaction_order_dependence.py
+++ b/mythril/analysis/modules/transaction_order_dependence.py
@@ -6,7 +6,7 @@ from mythril.analysis import solver
 from mythril.analysis.ops import *
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import TX_ORDER_DEPENDENCE
-from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError
+from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError, Neq
 from mythril.exceptions import UnsatError
 
 '''
@@ -83,7 +83,7 @@ def _can_change(constraints, variable):
         return False
     try:
         initial_value = int(str(model.eval(variable, model_completion=True)))
-        return _try_constraints(constraints, [variable != initial_value]) is not None
+        return _try_constraints(constraints, [Neq(variable, initial_value)]) is not None
     except AttributeError:
         return False
 

--- a/mythril/analysis/modules/unchecked_retval.py
+++ b/mythril/analysis/modules/unchecked_retval.py
@@ -2,6 +2,7 @@ from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNCHECKED_RET_VAL
 
 from mythril.laser.ethereum.svm import NodeFlags
+from mythril.laser.ethereum.smt_wrapper import formula_to_string
 import logging
 import re
 
@@ -43,7 +44,8 @@ def execute(statespace):
 
                 instr = state.get_current_instruction()
 
-                if instr['opcode'] == 'ISZERO' and re.search(r'retval', str(state.mstate.stack[-1])):
+                if instr['opcode'] == 'ISZERO' and \
+                   re.search(r'retval', formula_to_string(state.mstate.stack[-1])):
                     retval_checked = True
                     break
 
@@ -78,7 +80,8 @@ def execute(statespace):
                             _state = node.states[_idx]
                             _instr = _state.get_current_instruction()
 
-                            if _instr['opcode'] == 'ISZERO' and re.search(r'retval', str(_state .mstate.stack[-1])):
+                            if _instr['opcode'] == 'ISZERO' and \
+                               re.search(r'retval', formula_to_string(_state .mstate.stack[-1])):
                                 retval_checked = True
                                 break
 

--- a/mythril/analysis/ops.py
+++ b/mythril/analysis/ops.py
@@ -1,6 +1,7 @@
 from z3 import *
 from enum import Enum
 from mythril.laser.ethereum import util
+from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError
 
 
 class VarType(Enum):
@@ -21,7 +22,7 @@ class Variable:
 def get_variable(i):
     try:
         return Variable(util.get_concrete_int(i), VarType.CONCRETE)
-    except AttributeError:
+    except NotConcreteValueError:
         return Variable(simplify(i), VarType.SYMBOLIC)
 
 

--- a/mythril/analysis/ops.py
+++ b/mythril/analysis/ops.py
@@ -1,7 +1,7 @@
 from z3 import *
 from enum import Enum
 from mythril.laser.ethereum import util
-from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError
+from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError, simplify
 
 
 class VarType(Enum):

--- a/mythril/analysis/ops.py
+++ b/mythril/analysis/ops.py
@@ -1,4 +1,3 @@
-from z3 import *
 from enum import Enum
 from mythril.laser.ethereum import util
 from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError, simplify

--- a/mythril/analysis/solver.py
+++ b/mythril/analysis/solver.py
@@ -1,5 +1,7 @@
 from z3 import Solver, simplify, sat, unknown
 from mythril.exceptions import UnsatError
+from mythril.laser.ethereum.smt_wrapper import \
+    NotConcreteValueError, get_concrete_value
 import logging
 
 def get_model(constraints):
@@ -23,8 +25,8 @@ def pretty_print_model(model):
     for d in model.decls():
 
         try:
-            condition = "0x%x" % model[d].as_long()
-        except:
+            condition = "0x%x" % get_concrete_value(model[d])
+        except NotConcreteValueError:
             condition = str(simplify(model[d]))
 
         ret += ("%s: %s\n" % (d.name(), condition))

--- a/mythril/analysis/solver.py
+++ b/mythril/analysis/solver.py
@@ -1,20 +1,18 @@
-from z3 import Solver, sat, unknown
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    simplify
+    simplify, solve, Result, Solver
 import logging
 
 def get_model(constraints):
-    s = Solver()
-    s.set("timeout", 100000)
+    s = Solver(timeout=100000)
 
     for constraint in constraints:
-        s.add(constraint)
-    result = s.check()
-    if result == sat:
-        return s.model()
-    elif result == unknown:
+        s.add_assertion(constraint)
+    result = solve(s)
+    if result == Result.sat:
+        return s.get_model()
+    elif result == Result.unknown:
         logging.info("Timeout encountered while solving expression using z3")
     raise UnsatError
 
@@ -23,13 +21,13 @@ def pretty_print_model(model):
 
     ret = ""
 
-    for d in model.decls():
+    for (name, value) in model:
 
         try:
-            condition = "0x%x" % get_concrete_value(model[d])
+            condition = "0x%x" % get_concrete_value(value)
         except NotConcreteValueError:
-            condition = str(simplify(model[d]))
+            condition = str(simplify(value))
 
-        ret += ("%s: %s\n" % (d.name(), condition))
+        ret += ("%s: %s\n" % (name, condition))
 
     return ret

--- a/mythril/analysis/solver.py
+++ b/mythril/analysis/solver.py
@@ -1,7 +1,8 @@
-from z3 import Solver, simplify, sat, unknown
+from z3 import Solver, sat, unknown
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.smt_wrapper import \
-    NotConcreteValueError, get_concrete_value
+    NotConcreteValueError, get_concrete_value, \
+    simplify
 import logging
 
 def get_model(constraints):

--- a/mythril/analysis/symbolic.py
+++ b/mythril/analysis/symbolic.py
@@ -5,6 +5,8 @@ import copy
 import logging
 from .ops import get_variable, SStore, Call, VarType
 from mythril.laser.ethereum.strategy.basic import DepthFirstSearchStrategy, BreadthFirstSearchStrategy
+from mythril.laser.ethereum.smt_wrapper import \
+    BitVecVal, is_bv_value, get_concrete_value
 
 
 class SymExecWrapper:
@@ -100,19 +102,45 @@ class SymExecWrapper:
 
         # Find an SSTOR not constrained by caller that writes to storage index "index"
 
-        try:
-            for s in self.sstors[address][index]:
-
-                taint = True
-
-                for constraint in s.node.constraints:
-                    if "caller" in str(constraint):
-                        taint = False
-                        break
-
-                if taint:
-                    return s.node.function_name
-
+        if address not in self.sstors:
             return None
-        except KeyError:
+
+        index = self.__lookup_storage_index(self.sstors[address], index)
+        if index is None:
             return None
+
+        for s in self.sstors[address][index]:
+            taint = True
+
+            for constraint in s.node.constraints:
+                if "caller" in str(constraint):
+                    taint = False
+                    break
+
+            if taint:
+                return s.node.function_name
+
+        return None
+
+
+    def __lookup_storage_index(self, storage, index):
+        if index in storage:
+            return index
+
+        if isinstance(index, str):
+            try:
+                index = int(index, 0)
+            except:
+                return None
+            if index in storage:
+                return index
+
+        if isinstance(index, int):
+            index = BitVecVal(int(index), 256)
+        elif is_bv_value(index):
+            index = get_concrete_value(index)
+        else:
+            return None
+        index = str(index)
+
+        return index if index in storage else None

--- a/mythril/analysis/traceexplore.py
+++ b/mythril/analysis/traceexplore.py
@@ -1,5 +1,5 @@
-from z3 import Z3Exception, simplify
 from mythril.laser.ethereum.svm import NodeFlags
+from mythril.laser.ethereum.smt_wrapper import simplify, SimplificationError
 import re
 
 colors = [
@@ -87,7 +87,7 @@ def get_serializable_statespace(statespace):
 
             try:
                 label = str(simplify(edge.condition)).replace("\n", "")
-            except Z3Exception:
+            except SimplificationError:
                 label = str(edge.condition).replace("\n", "")
 
         label = re.sub("([^_])([\d]{2}\d+)", lambda m: m.group(1) + hex(int(m.group(2))), label)

--- a/mythril/laser/ethereum/call.py
+++ b/mythril/laser/ethereum/call.py
@@ -2,6 +2,7 @@ import logging
 from z3 import simplify
 import mythril.laser.ethereum.util as util
 from mythril.laser.ethereum.state import Account, CalldataType, GlobalState
+from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError
 from mythril.support.loader import DynLoader
 import re
 
@@ -48,7 +49,7 @@ def get_callee_address(global_state:GlobalState, dynamic_loader: DynLoader, symb
 
     try:
         callee_address = hex(util.get_concrete_int(symbolic_to_address))
-    except AttributeError:
+    except NotConcreteValueError:
         logging.debug("Symbolic call encountered")
 
         match = re.search(r'storage_(\d+)', str(simplify(symbolic_to_address)))
@@ -130,7 +131,7 @@ def get_call_data(global_state, memory_start, memory_size, pad=True):
             call_data += [0] * (32 - len(call_data))
         call_data_type = CalldataType.CONCRETE
         logging.debug("Calldata: " + str(call_data))
-    except AttributeError:
+    except NotConcreteValueError:
         logging.info("Unsupported symbolic calldata offset")
         call_data_type = CalldataType.SYMBOLIC
         call_data = []

--- a/mythril/laser/ethereum/call.py
+++ b/mythril/laser/ethereum/call.py
@@ -1,7 +1,8 @@
 import logging
 import mythril.laser.ethereum.util as util
 from mythril.laser.ethereum.state import Account, CalldataType, GlobalState
-from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError, simplify
+from mythril.laser.ethereum.smt_wrapper import \
+    NotConcreteValueError, simplify, formula_to_string
 from mythril.support.loader import DynLoader
 import re
 
@@ -51,8 +52,8 @@ def get_callee_address(global_state:GlobalState, dynamic_loader: DynLoader, symb
     except NotConcreteValueError:
         logging.debug("Symbolic call encountered")
 
-        match = re.search(r'storage_(\d+)', str(simplify(symbolic_to_address)))
-        logging.debug("CALL to: " + str(simplify(symbolic_to_address)))
+        match = re.search(r'storage_(\d+)', formula_to_string(simplify(symbolic_to_address)))
+        logging.debug("CALL to: " + formula_to_string(simplify(symbolic_to_address)))
 
         if match is None or dynamic_loader is None:
             raise ValueError()

--- a/mythril/laser/ethereum/call.py
+++ b/mythril/laser/ethereum/call.py
@@ -1,8 +1,7 @@
 import logging
-from z3 import simplify
 import mythril.laser.ethereum.util as util
 from mythril.laser.ethereum.state import Account, CalldataType, GlobalState
-from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError
+from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError, simplify
 from mythril.support.loader import DynLoader
 import re
 

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -3,9 +3,6 @@ import logging
 from copy import copy, deepcopy
 
 from ethereum import utils
-from z3 import Extract, UDiv, Concat, ULT, UGT, Not, \
-    is_false, is_expr, URem, SRem, BitVec, is_true, BitVecVal, If, Or, \
-    is_bool, is_bv_value
 
 import mythril.laser.ethereum.natives as natives
 import mythril.laser.ethereum.util as helper
@@ -19,8 +16,9 @@ from mythril.laser.ethereum.transaction import MessageCallTransaction, Transacti
     ContractCreationTransaction
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    Eq, Neq, SLT, SGT, SDiv, \
-    simplify
+    Eq, Neq, Or, Not, SLT, SGT, SDiv, \
+    simplify, BitVec, BitVecVal, If, is_bool, is_expr, Concat, Extract, \
+    is_bv_value, ULT, UGT, is_true, is_false, UDiv, URem, SRem
 
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -4,7 +4,7 @@ from copy import copy, deepcopy
 
 from ethereum import utils
 from z3 import Extract, UDiv, simplify, Concat, ULT, UGT, BitVecNumRef, Not, \
-    is_false, is_expr, ExprRef, URem, SRem, BitVec, Solver, is_true, BitVecVal, If, BoolRef, Or
+    is_false, is_expr, ExprRef, URem, SRem, BitVec, is_true, BitVecVal, If, BoolRef, Or
 
 import mythril.laser.ethereum.natives as natives
 import mythril.laser.ethereum.util as helper
@@ -820,9 +820,6 @@ class Instruction:
 
             storage_keys = global_state.environment.active_account.storage.keys()
             keccak_keys = filter(keccak_function_manager.is_keccak, storage_keys)
-
-            solver = Solver()
-            solver.set(timeout=1000)
 
             results = []
             new = False

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -4,7 +4,8 @@ from copy import copy, deepcopy
 
 from ethereum import utils
 from z3 import Extract, UDiv, simplify, Concat, ULT, UGT, BitVecNumRef, Not, \
-    is_false, is_expr, ExprRef, URem, SRem, BitVec, is_true, BitVecVal, If, BoolRef, Or
+    is_false, is_expr, ExprRef, URem, SRem, BitVec, is_true, BitVecVal, If, Or, \
+    is_bool
 
 import mythril.laser.ethereum.natives as natives
 import mythril.laser.ethereum.util as helper
@@ -128,9 +129,9 @@ class Instruction:
     def and_(self, global_state):
         stack = global_state.mstate.stack
         op1, op2 = stack.pop(), stack.pop()
-        if type(op1) == BoolRef:
+        if is_bool(op1):
             op1 = If(op1, BitVecVal(1, 256), BitVecVal(0, 256))
-        if type(op2) == BoolRef:
+        if is_bool(op2):
             op2 = If(op2, BitVecVal(1, 256), BitVecVal(0, 256))
 
         stack.append(op1 & op2)
@@ -142,10 +143,10 @@ class Instruction:
         stack = global_state.mstate.stack
         op1, op2 = stack.pop(), stack.pop()
 
-        if type(op1) == BoolRef:
+        if is_bool(op1):
             op1 = If(op1, BitVecVal(1, 256), BitVecVal(0, 256))
 
-        if type(op2) == BoolRef:
+        if is_bool(op2):
             op2 = If(op2, BitVecVal(1, 256), BitVecVal(0, 256))
 
         stack.append(op1 | op2)
@@ -319,10 +320,10 @@ class Instruction:
         op1 = state.stack.pop()
         op2 = state.stack.pop()
 
-        if type(op1) == BoolRef:
+        if is_bool(op1):
             op1 = If(op1, BitVecVal(1, 256), BitVecVal(0, 256))
 
-        if type(op2) == BoolRef:
+        if is_bool(op2):
             op2 = If(op2, BitVecVal(1, 256), BitVecVal(0, 256))
 
         exp = op1 == op2
@@ -335,7 +336,7 @@ class Instruction:
         state = global_state.mstate
 
         val = state.stack.pop()
-        exp = val == False if type(val) == BoolRef else val == 0
+        exp = val == False if is_bool(val) else val == 0
         state.stack.append(exp)
 
         return [global_state]
@@ -903,9 +904,9 @@ class Instruction:
             return [global_state]
 
         # False case
-        negated = simplify(Not(condition)) if type(condition) == BoolRef else condition == 0
+        negated = simplify(Not(condition)) if is_bool(condition) else condition == 0
 
-        if (type(negated) == bool and negated) or (type(negated) == BoolRef and not is_false(negated)):
+        if (type(negated) == bool and negated) or (is_bool(negated) and not is_false(negated)):
             new_state = copy(global_state)
             new_state.mstate.depth += 1
             new_state.mstate.pc += 1
@@ -924,9 +925,9 @@ class Instruction:
 
         instr = disassembly.instruction_list[index]
 
-        condi = simplify(condition) if type(condition) == BoolRef else condition != 0
+        condi = simplify(condition) if is_bool(condition) else condition != 0
         if instr['opcode'] == "JUMPDEST":
-            if (type(condi) == bool and condi) or (type(condi) == BoolRef and not is_false(condi)):
+            if (type(condi) == bool and condi) or (is_bool(condi) and not is_false(condi)):
                 new_state = copy(global_state)
                 new_state.mstate.pc = index
                 new_state.mstate.depth += 1

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -19,7 +19,7 @@ from mythril.laser.ethereum.transaction import MessageCallTransaction, Transacti
     ContractCreationTransaction
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    Eq, Neq
+    Eq, Neq, SLT, SGT
 
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1
@@ -302,7 +302,7 @@ class Instruction:
     @StateTransition()
     def slt_(self, global_state):
         state = global_state.mstate
-        exp = util.pop_bitvec(state) < util.pop_bitvec(state)
+        exp = SLT(util.pop_bitvec(state), util.pop_bitvec(state))
         state.stack.append(exp)
         return [global_state]
 
@@ -310,7 +310,7 @@ class Instruction:
     def sgt_(self, global_state):
         state = global_state.mstate
 
-        exp = util.pop_bitvec(state) > util.pop_bitvec(state)
+        exp = SGT(util.pop_bitvec(state), util.pop_bitvec(state))
         state.stack.append(exp)
         return [global_state]
 

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -3,9 +3,9 @@ import logging
 from copy import copy, deepcopy
 
 from ethereum import utils
-from z3 import Extract, UDiv, simplify, Concat, ULT, UGT, BitVecNumRef, Not, \
+from z3 import Extract, UDiv, simplify, Concat, ULT, UGT, Not, \
     is_false, is_expr, ExprRef, URem, SRem, BitVec, is_true, BitVecVal, If, Or, \
-    is_bool
+    is_bool, is_bv_value
 
 import mythril.laser.ethereum.natives as natives
 import mythril.laser.ethereum.util as helper
@@ -253,7 +253,7 @@ class Instruction:
         state = global_state.mstate
 
         base, exponent = util.pop_bitvec(state), util.pop_bitvec(state)
-        if (type(base) != BitVecNumRef) or (type(exponent) != BitVecNumRef):
+        if (not is_bv_value(base)) or (not is_bv_value(exponent)):
             state.stack.append(global_state.new_bitvec("(" + str(simplify(base)) + ")**(" + str(simplify(exponent)) + ")", 256))
         else:
             state.stack.append(pow(get_concrete_value(base), get_concrete_value(exponent), 2**256))
@@ -988,7 +988,7 @@ class Instruction:
 
         # Often the target of the suicide instruction will be symbolic
         # If it isn't then well transfer the balance to the indicated contract
-        if isinstance(target, BitVecNumRef):
+        if is_bv_value(target):
             target = '0x' + hex(get_concrete_value(target))[-40:]
         if isinstance(target, str):
             try:

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -19,7 +19,7 @@ from mythril.laser.ethereum.transaction import MessageCallTransaction, Transacti
     ContractCreationTransaction
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    Eq, Neq, SLT, SGT
+    Eq, Neq, SLT, SGT, SDiv
 
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1
@@ -220,7 +220,7 @@ class Instruction:
         if s1 == 0:
             global_state.mstate.stack.append(BitVecVal(0, 256))
         else:
-            global_state.mstate.stack.append(s0 / s1)
+            global_state.mstate.stack.append(SDiv(s0, s1))
         return [global_state]
 
     @StateTransition()

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -3,7 +3,7 @@ import logging
 from copy import copy, deepcopy
 
 from ethereum import utils
-from z3 import Extract, UDiv, simplify, Concat, ULT, UGT, Not, \
+from z3 import Extract, UDiv, Concat, ULT, UGT, Not, \
     is_false, is_expr, URem, SRem, BitVec, is_true, BitVecVal, If, Or, \
     is_bool, is_bv_value
 
@@ -19,7 +19,8 @@ from mythril.laser.ethereum.transaction import MessageCallTransaction, Transacti
     ContractCreationTransaction
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    Eq, Neq, SLT, SGT, SDiv
+    Eq, Neq, SLT, SGT, SDiv, \
+    simplify
 
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -207,7 +207,13 @@ class Instruction:
     @StateTransition()
     def div_(self, global_state):
         op0, op1 = util.pop_bitvec(global_state.mstate), util.pop_bitvec(global_state.mstate)
-        if op1 == 0:
+
+        try:
+            is_op1_zero = util.get_concrete_int(op1) == 0
+        except NotConcreteValueError:
+            is_op1_zero = False
+
+        if is_op1_zero:
             global_state.mstate.stack.append(BitVecVal(0, 256))
         else:
             global_state.mstate.stack.append(UDiv(op0, op1))
@@ -216,7 +222,13 @@ class Instruction:
     @StateTransition()
     def sdiv_(self, global_state):
         s0, s1 = util.pop_bitvec(global_state.mstate), util.pop_bitvec(global_state.mstate)
-        if s1 == 0:
+
+        try:
+            is_s1_zero = util.get_concrete_int(s1) == 0
+        except NotConcreteValueError:
+            is_s1_zero = False
+
+        if is_s1_zero:
             global_state.mstate.stack.append(BitVecVal(0, 256))
         else:
             global_state.mstate.stack.append(SDiv(s0, s1))
@@ -225,13 +237,21 @@ class Instruction:
     @StateTransition()
     def mod_(self, global_state):
         s0, s1 = util.pop_bitvec(global_state.mstate), util.pop_bitvec(global_state.mstate)
-        global_state.mstate.stack.append(0 if s1 == 0 else URem(s0, s1))
+        try:
+            is_s1_zero = util.get_concrete_int(s1) == 0
+        except NotConcreteValueError:
+            is_s1_zero = False
+        global_state.mstate.stack.append(0 if is_s1_zero else URem(s0, s1))
         return [global_state]
 
     @StateTransition()
     def smod_(self, global_state):
         s0, s1 = util.pop_bitvec(global_state.mstate), util.pop_bitvec(global_state.mstate)
-        global_state.mstate.stack.append(0 if s1 == 0 else SRem(s0, s1))
+        try:
+            is_s1_zero = util.get_concrete_int(s1) == 0
+        except NotConcreteValueError:
+            is_s1_zero = False
+        global_state.mstate.stack.append(0 if is_s1_zero else SRem(s0, s1))
         return [global_state]
 
     @StateTransition()

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -4,7 +4,7 @@ from copy import copy, deepcopy
 
 from ethereum import utils
 from z3 import Extract, UDiv, simplify, Concat, ULT, UGT, Not, \
-    is_false, is_expr, ExprRef, URem, SRem, BitVec, is_true, BitVecVal, If, Or, \
+    is_false, is_expr, URem, SRem, BitVec, is_true, BitVecVal, If, Or, \
     is_bool, is_bv_value
 
 import mythril.laser.ethereum.natives as natives
@@ -169,7 +169,7 @@ class Instruction:
     def byte_(self, global_state):
         mstate = global_state.mstate
         op0, op1 = mstate.stack.pop(), mstate.stack.pop()
-        if not isinstance(op1, ExprRef):
+        if not is_expr(op1):
             op1 = BitVecVal(op1, 256)
         try:
             index = util.get_concrete_int(op0)
@@ -852,7 +852,7 @@ class Instruction:
                 global_state.environment.active_account.address] = global_state.environment.active_account
 
             global_state.environment.active_account.storage[index] =\
-                value if not isinstance(value, ExprRef) else simplify(value)
+                value if not is_expr(value) else simplify(value)
         except KeyError:
             logging.debug("Error writing to storage: Invalid index")
 
@@ -1107,8 +1107,8 @@ class Instruction:
             return [global_state]
 
         try:
-            memory_out_offset = util.get_concrete_int(memory_out_offset) if isinstance(memory_out_offset, ExprRef) else memory_out_offset
-            memory_out_size = util.get_concrete_int(memory_out_size) if isinstance(memory_out_size, ExprRef) else memory_out_size
+            memory_out_offset = util.get_concrete_int(memory_out_offset) if is_expr(memory_out_offset) else memory_out_offset
+            memory_out_size = util.get_concrete_int(memory_out_size) if is_expr(memory_out_size) else memory_out_size
         except NotConcreteValueError:
             global_state.mstate.stack.append(global_state.new_bitvec("retval_" + str(instr['address']), 256))
             return [global_state]
@@ -1175,8 +1175,8 @@ class Instruction:
             return [global_state]
 
         try:
-            memory_out_offset = util.get_concrete_int(memory_out_offset) if isinstance(memory_out_offset, ExprRef) else memory_out_offset
-            memory_out_size = util.get_concrete_int(memory_out_size) if isinstance(memory_out_size, ExprRef) else memory_out_size
+            memory_out_offset = util.get_concrete_int(memory_out_offset) if is_expr(memory_out_offset) else memory_out_offset
+            memory_out_size = util.get_concrete_int(memory_out_size) if is_expr(memory_out_size) else memory_out_size
         except NotConcreteValueError:
             global_state.mstate.stack.append(global_state.new_bitvec("retval_" + str(instr['address']), 256))
             return [global_state]
@@ -1245,10 +1245,8 @@ class Instruction:
             return [global_state]
 
         try:
-            memory_out_offset = util.get_concrete_int(memory_out_offset) if isinstance(memory_out_offset,
-                                                                                       ExprRef) else memory_out_offset
-            memory_out_size = util.get_concrete_int(memory_out_size) if isinstance(memory_out_size,
-                                                                                   ExprRef) else memory_out_size
+            memory_out_offset = util.get_concrete_int(memory_out_offset) if is_expr(memory_out_offset) else memory_out_offset
+            memory_out_size = util.get_concrete_int(memory_out_size) if is_expr(memory_out_size) else memory_out_size
         except NotConcreteValueError:
             global_state.mstate.stack.append(global_state.new_bitvec("retval_" + str(instr['address']), 256))
             return [global_state]

--- a/mythril/laser/ethereum/keccak.py
+++ b/mythril/laser/ethereum/keccak.py
@@ -1,4 +1,4 @@
-from z3 import ExprRef
+from mythril.laser.ethereum.smt_wrapper import Types
 
 class KeccakFunctionManager:
     def __init__(self):
@@ -7,11 +7,11 @@ class KeccakFunctionManager:
     def is_keccak(self, expression) -> bool:
         return str(expression) in self.keccak_expression_mapping.keys()
 
-    def get_argument(self, expression) -> ExprRef:
+    def get_argument(self, expression) -> Types.Expr:
         if not self.is_keccak(expression):
             raise ValueError("Expression is not a recognized keccac result")
         return self.keccak_expression_mapping[str(expression)][1]
 
-    def add_keccak(self, expression: ExprRef, argument: ExprRef):
+    def add_keccak(self, expression: Types.Expr, argument: Types.Expr):
         index = str(expression)
         self.keccak_expression_mapping[index] = (expression, argument)

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -1,4 +1,3 @@
-from typing import Any
 from z3 import ExprRef
 
 
@@ -31,3 +30,27 @@ def get_concrete_value(expr: Types.Expr):
     except AttributeError:
         pass
     raise NotConcreteValueError(expr)
+
+
+def Eq(lhs, rhs) -> Types.Expr:
+    """
+    Make an equation formula `lhs == rhs`
+
+    :param lhs: the left side of the equation formula
+    :param rhs: the right side of the equation formula
+
+    :return: a formula `lhs == rhs`
+    """
+    return lhs == rhs
+
+
+def Neq(lhs, rhs) -> Types.Expr:
+    """
+    Make an inequation formula `lhs <> rhs`
+
+    :param lhs: the left side of the inequation formula
+    :param rhs: the right side of the inequation formula
+
+    :return: a formula `lhs <> rhs`
+    """
+    return lhs != rhs

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -91,3 +91,21 @@ def SGT(lhs, rhs) -> Types.Expr:
         raise TypeError
 
     return lhs > rhs
+
+
+def SDiv(dividend, divisor) -> Types.Expr:
+    """
+    Make a signed division `dividend / divisor`.
+
+    :param dividend: the dividend
+    :param divisor: the divisor
+
+    :return: a signed division `dividend / divisor`
+
+    :raise TypeError: if none of `dividend` or `divisor` is the bit vector
+    """
+
+    if not (is_bv(dividend) or is_bv(divisor)):
+        raise TypeError
+
+    return dividend / divisor

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -1,4 +1,5 @@
 from z3 import ExprRef, is_bv
+from z3 import simplify as z3_simplify
 
 
 class Types:
@@ -109,3 +110,30 @@ def SDiv(dividend, divisor) -> Types.Expr:
         raise TypeError
 
     return dividend / divisor
+
+
+class SimplificationError(Exception):
+    """
+    Raise if the simplification fails.
+    """
+
+    def __init__(self, reason):
+        self.reason = reason
+
+
+def simplify(expr: Types.Expr) -> Types.Expr:
+    """
+    Simplify the constrain expression `expr`.
+
+    :param expr: the expression to be simplified
+
+    :return: the simplified form of `expr`
+
+    :raise SimplificationError: if any error occurs
+    """
+
+    try:
+        return z3_simplify(expr)
+    except Exception as e:
+        reason = str(e)
+    raise SimplificationError(reason)

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -1,4 +1,4 @@
-from z3 import ExprRef
+from z3 import ExprRef, is_bv
 
 
 class Types:
@@ -11,7 +11,7 @@ class NotConcreteValueError(Exception):
     Raise if no concrete value can be got.
     """
 
-    def __init__(self, expr: Any):
+    def __init__(self, expr):
         self.expr = expr
 
 
@@ -54,3 +54,40 @@ def Neq(lhs, rhs) -> Types.Expr:
     :return: a formula `lhs <> rhs`
     """
     return lhs != rhs
+
+
+def SLT(lhs, rhs) -> Types.Expr:
+    """
+    Make a signed less-than comparison `lhs < rhs`
+
+    :param lhs: the left side of the comparison
+    :param rhs: the right side of the comparison
+
+    :return: a signed less-than comparison `lhs < rhs`
+
+    :raise TypeError: if none of them is the bit vector
+    """
+
+    if not (is_bv(lhs) or is_bv(rhs)):
+        raise TypeError
+
+    return lhs < rhs
+
+
+def SGT(lhs, rhs) -> Types.Expr:
+    """
+    Make a signed greater-than comparison `lhs > rhs`, or a shortcut formula
+    True or False.
+
+    :param lhs: the left side of the comparison
+    :param rhs: the right side of the comparison
+
+    :return: a signed greater-than comparison `lhs > rhs`
+
+    :raise TypeError: if none of them is the bit vector
+    """
+
+    if not (is_bv(lhs) or is_bv(rhs)):
+        raise TypeError
+
+    return lhs > rhs

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -552,3 +552,39 @@ def solve(s: SolverType, assumptions=None):
         return Result.sat if result else Result.unsat
     except SolverReturnedUnknownResultError:
         return Result.unknown
+
+
+def is_always_true(formula, timeout=10000) -> bool:
+    """
+    Check whether `formula` always holds.
+
+    :param formula: the formula to be checked
+    :param timeout: the time limitation milliseconds of constraint solving.
+                    The default value is 10 s.
+
+    :return: True if `formula` always holds; False, otherwise (including the
+             unknown and timeout cases).
+    """
+
+    try:
+        return Solver(timeout=timeout).is_unsat(Not(formula))
+    except SolverReturnedUnknownResultError:
+        return False
+
+
+def is_always_false(formula, timeout=10000) -> bool:
+    """
+    Check whether `formula` never holds.
+
+    :param formula: the formula to be checked
+    :param timeout: the time limitation milliseconds of constraint solving.
+                    The default value is 10 s.
+
+    :return: True if `formula` never holds; False, otherwise (including the
+             unknown and timeout cases).
+    """
+
+    try:
+        return Solver(timeout=timeout).is_unsat(formula)
+    except SolverReturnedUnknownResultError:
+        return False

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -588,3 +588,22 @@ def is_always_false(formula, timeout=10000) -> bool:
         return Solver(timeout=timeout).is_unsat(formula)
     except SolverReturnedUnknownResultError:
         return False
+
+
+def formula_to_string(formula) -> str:
+    """
+    Get the stringified `formula`.
+
+    If `formula` is not a formula, the default string representation generated
+    by `__str__()` will be used.
+
+    Otherwise, a serialized string representation will be used. We do not use
+    the default `__str__()`, because it may omit some part of the formula, which
+    in turn may cause issues when pattern matching the stringified formula.
+
+    :param formula: the formula
+
+    :return: the stringified `formula`
+    """
+
+    return formula.serialize() if is_expr(formula) else str(formula)

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -1,0 +1,33 @@
+from typing import Any
+from z3 import ExprRef
+
+
+class Types:
+    #: Constraints, formulas and items are constraint expressions.
+    Expr = ExprRef
+
+
+class NotConcreteValueError(Exception):
+    """
+    Raise if no concrete value can be got.
+    """
+
+    def __init__(self, expr: Any):
+        self.expr = expr
+
+
+def get_concrete_value(expr: Types.Expr):
+    """
+    Get the concrete value of a constraint expression `expr`
+
+    :param expr: the constraint expression
+
+    :return: the concrete value of `expr`
+
+    :raise NotConcreteValueError: if `expr` is not a concrete value
+    """
+    try:
+        return expr.as_long()
+    except AttributeError:
+        pass
+    raise NotConcreteValueError(expr)

--- a/mythril/laser/ethereum/smt_wrapper.py
+++ b/mythril/laser/ethereum/smt_wrapper.py
@@ -1,5 +1,6 @@
-from z3 import ExprRef, is_bv
+from z3 import ExprRef
 from z3 import simplify as z3_simplify
+import z3
 
 
 class Types:
@@ -137,3 +138,268 @@ def simplify(expr: Types.Expr) -> Types.Expr:
     except Exception as e:
         reason = str(e)
     raise SimplificationError(reason)
+
+
+def is_expr(expr) -> bool:
+    """
+    Check whether `expr` is a constraint expression.
+
+    :param expr: the expression to be checked
+
+    :return: True if `expr` is a formula; False, otherwise.
+    """
+
+    return z3.is_expr(expr)
+
+
+def is_bv_value(expr) -> bool:
+    """
+    Check whether `expr` is a concrete bit vector value.
+
+    :param expr: the expression to be checked
+
+    :return: True if `expr` is a concrete bit vector value; False, otherwise.
+    """
+
+    return z3.is_bv_value(expr)
+
+
+def is_bv(expr) -> bool:
+    """
+    Check whether `expr` is a bit vector.
+
+    :param expr: the expression to be checked
+
+    :return: True if `expr` is a bit vector; False, otherwise.
+    """
+
+    return z3.is_bv(expr)
+
+
+def is_bool(expr) -> bool:
+    """
+    Check whether `expr` is a boolean constraint expression.
+
+    :param expr: the expression to be checked
+
+    :return: True if `expr` is a boolen constraint expression; False, otherwise.
+    """
+
+    return z3.is_bool(expr)
+
+
+def is_true(expr) -> bool:
+    """
+    Check whether `expr` is a True constraint expression.
+
+    :param expr: the expression to be checked
+
+    :return: True if `expr` is a True constraint expression; False, otherwise.
+    """
+
+    return z3.is_true(expr)
+
+
+def is_false(expr) -> bool:
+    """
+    Check whether `expr` is a False constraint expression.
+
+    :param expr: the expression to be checked
+
+    :return: True if `expr` is a False constraint expression; False, otherwise.
+    """
+
+    return z3.is_false(expr)
+
+
+def Not(op) -> Types.Expr:
+    """
+    Create a Not constraint expression.
+
+    :param op: the operand
+
+    :return: a Not expression
+    """
+
+    return z3.Not(op)
+
+
+def BitVec(name: str, width: int) -> Types.Expr:
+    """
+    Create a bit vector symbol `name` which is `width` bits wide.
+
+    :param name: the symbol name
+    :param width: the number of bits
+
+    :return: a bit vector symbol
+    """
+
+    return z3.BitVec(name, width)
+
+
+def BitVecVal(val: int, width: int) -> Types.Expr:
+    """
+    Create a bit vector which is `width` bits wide and represent an integer `val`.
+
+    :param val: the value of the bit vector
+    :param width: the number of bits of the bit vector
+
+    :return: a bit vector value
+    """
+
+    return z3.BitVecVal(val, width)
+
+
+def Concat(*args) -> Types.Expr:
+    """
+    Concatenate a sequence of bit vectors.
+
+    :param args: the sequence of bit vectors
+
+    :return: the concatenation of the sequence of bit vectors
+    """
+
+    return z3.Concat(*args)
+
+
+def Extract(last_bit: int, first_bit: int, bv) -> Types.Expr:
+    """
+    Create an expression that extract bits from `first_bit` to `last_bit`
+    (included) from a bit vector `bv`.
+
+    :param last_bit: the last bit (included) to be extracted
+    :param first_bit: the first bit to be extracted
+    :param bv: the bit vector
+
+    :return: an expression to extract bits
+    """
+
+    return z3.Extract(last_bit, first_bit, bv)
+
+
+def And(*args) -> Types.Expr:
+    """
+    Create a logical and expression `\\/ *args`.
+
+    :param args: the sub-exprs of the expression
+
+    :return: a logical and expression
+    """
+
+    return z3.And(*args)
+
+
+def Or(*args) -> Types.Expr:
+    """
+    Create a logical or expression `\\/ *args`.
+
+    :param args: the sub-exprs of the expression
+
+    :return: a logical or expression
+    """
+
+    return z3.Or(*args)
+
+
+def ULT(lhs, rhs) -> Types.Expr:
+    """
+    Create an unsigned less-than comparison `lhs < rhs`.
+
+    :param lhs: the left operand
+    :param rhs: the right operand
+
+    :return: `lhs < rhs`
+
+    :raise TypeError: if none of `lhs` and `rhs` is the bit vector
+    """
+
+    if not (is_bv(lhs) or is_bv(rhs)):
+        raise TypeError
+
+    return z3.ULT(lhs, rhs)
+
+
+def UGT(lhs, rhs) -> Types.Expr:
+    """
+    Create an unsigned greater-than comparison `lhs > rhs`.
+
+    :param lhs: the left operand
+    :param rhs: the right operand
+
+    :return: `lhs > rhs`
+
+    :raise TypeError: if none of `lhs` and `rhs` is the bit vector
+    """
+
+    if not (is_bv(lhs) or is_bv(rhs)):
+        raise TypeError
+
+    return z3.UGT(lhs, rhs)
+
+
+def If(cond, then_op, else_op) -> Types.Expr:
+    """
+    Create a if-then-else expression `Ite cond then_op else_op`.
+
+    :param cond: the condition to be checked
+    :param then_op: the then operand
+    :param else_op: the else operand
+
+    :return: a if-then-else expression
+    """
+
+    return z3.If(cond, then_op, else_op)
+
+
+def UDiv(dividend, divisor) -> Types.Expr:
+    """
+    Create an unsigned division `dividend / divisor`.
+
+    :param dividend: the dividend
+    :param divisor: the divisor
+
+    :return: an unsigned division
+
+    :raise TypeError: if none of `dividend` or `divisor` is the bit vector
+    """
+
+    if not (is_bv(dividend) or is_bv(divisor)):
+        raise TypeError
+
+    return z3.UDiv(dividend, divisor)
+
+
+def URem(dividend, divisor) -> Types.Expr:
+    """
+    Create an unsigned reminder `dividend % divisor`.
+
+    :param dividend: the dividend
+    :param divisor: the divisor
+
+    :return: an unsigned reminder
+
+    :raise TypeError: if none of `dividend` or `divisor` is the bit vector
+    """
+
+    if not (is_bv(dividend) or is_bv(divisor)):
+        raise TypeError
+
+    return z3.URem(dividend, divisor)
+
+
+def SRem(dividend, divisor) -> Types.Expr:
+    """
+    Create a signed reminder `dividend % divisor`.
+
+    :param dividend: the dividend
+    :param divisor: the divisor
+
+    :return: a signed reminder
+
+    :raise TypeError: if none of `dividend` or `divisor` is the bit vector
+    """
+
+    if not (is_bv(dividend) or is_bv(divisor)):
+        raise TypeError
+
+    return z3.SRem(dividend, divisor)

--- a/mythril/laser/ethereum/state.py
+++ b/mythril/laser/ethereum/state.py
@@ -1,10 +1,10 @@
-from z3 import BitVec, BitVecVal, Solver, ExprRef, sat
 from mythril.disassembler.disassembly import Disassembly
 from copy import copy, deepcopy
 from enum import Enum
 from random import randint
 
 from mythril.laser.ethereum.evm_exceptions import StackOverflowException, StackUnderflowException
+from mythril.laser.ethereum.smt_wrapper import BitVec, BitVecVal
 
 
 class CalldataType(Enum):

--- a/mythril/laser/ethereum/taint_analysis.py
+++ b/mythril/laser/ethereum/taint_analysis.py
@@ -1,6 +1,7 @@
 import logging, copy
 import mythril.laser.ethereum.util as helper
 from mythril.laser.ethereum.cfg import JumpType
+from mythril.laser.ethereum.smt_wrapper import NotConcreteValueError
 
 class TaintRecord:
     """
@@ -213,7 +214,7 @@ class TaintRunner:
         _ = record.stack.pop()
         try:
             index = helper.get_concrete_int(op0)
-        except AttributeError:
+        except NotConcreteValueError:
             logging.debug("Can't MLOAD taint track symbolically")
             record.stack.append(False)
             return
@@ -225,7 +226,7 @@ class TaintRunner:
         _, value_taint = record.stack.pop(), record.stack.pop()
         try:
             index = helper.get_concrete_int(op0)
-        except AttributeError:
+        except NotConcreteValueError:
             logging.debug("Can't mstore taint track symbolically")
             return
 
@@ -236,7 +237,7 @@ class TaintRunner:
         _ = record.stack.pop()
         try:
             index = helper.get_concrete_int(op0)
-        except AttributeError:
+        except NotConcreteValueError:
             logging.debug("Can't MLOAD taint track symbolically")
             record.stack.append(False)
             return
@@ -248,7 +249,7 @@ class TaintRunner:
         _, value_taint = record.stack.pop(), record.stack.pop()
         try:
             index = helper.get_concrete_int(op0)
-        except AttributeError:
+        except NotConcreteValueError:
             logging.debug("Can't mstore taint track symbolically")
             return
 

--- a/mythril/laser/ethereum/transaction/concolic.py
+++ b/mythril/laser/ethereum/transaction/concolic.py
@@ -1,5 +1,4 @@
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction, ContractCreationTransaction, get_next_transaction_id
-from z3 import BitVec
 from mythril.laser.ethereum.state import GlobalState, Environment, CalldataType, Account, WorldState
 from mythril.disassembler.disassembly import Disassembly
 from mythril.laser.ethereum.cfg import Node, Edge, JumpType

--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -1,4 +1,3 @@
-from z3 import BitVec, Extract, Not
 from logging import debug
 
 from mythril.disassembler.disassembly import Disassembly
@@ -6,6 +5,7 @@ from mythril.laser.ethereum.cfg import Node, Edge, JumpType
 from mythril.laser.ethereum.state import CalldataType
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction, ContractCreationTransaction,\
     get_next_transaction_id
+from mythril.laser.ethereum.smt_wrapper import BitVec
 
 def execute_message_call(laser_evm, callee_address):
     """ Executes a message call transaction from all open states """

--- a/mythril/laser/ethereum/transaction/transaction_models.py
+++ b/mythril/laser/ethereum/transaction/transaction_models.py
@@ -1,7 +1,7 @@
 import logging
 from mythril.disassembler.disassembly import Disassembly
 from mythril.laser.ethereum.state import GlobalState, Environment, WorldState
-from z3 import BitVec
+from mythril.laser.ethereum.smt_wrapper import BitVec
 import array
 
 _next_transaction_id = 0

--- a/mythril/laser/ethereum/util.py
+++ b/mythril/laser/ethereum/util.py
@@ -4,7 +4,7 @@ import logging
 
 import sha3 as _sha3
 
-from mythril.laser.ethereum.smt_wrapper import get_concrete_value
+from mythril.laser.ethereum.smt_wrapper import get_concrete_value, simplify
 
 
 TT256 = 2 ** 256

--- a/mythril/laser/ethereum/util.py
+++ b/mythril/laser/ethereum/util.py
@@ -57,7 +57,7 @@ def pop_bitvec(state):
 
     item = state.stack.pop()
 
-    if type(item) == BoolRef:
+    if is_bool(item):
         return If(item, BitVecVal(1, 256), BitVecVal(0, 256))
     elif type(item) == bool:
         if item:
@@ -75,7 +75,7 @@ def get_concrete_int(item):
         return item
     elif isinstance(item, BitVecNumRef):
         return get_concrete_value(item)
-    elif isinstance(item, BoolRef):
+    elif is_bool(item):
         simplified = simplify(item)
         if is_false(simplified):
             return 0

--- a/mythril/laser/ethereum/util.py
+++ b/mythril/laser/ethereum/util.py
@@ -4,6 +4,8 @@ import logging
 
 import sha3 as _sha3
 
+from mythril.laser.ethereum.smt_wrapper import get_concrete_value
+
 
 TT256 = 2 ** 256
 TT256M1 = 2 ** 256 - 1
@@ -72,7 +74,7 @@ def get_concrete_int(item):
     if isinstance(item, int):
         return item
     elif isinstance(item, BitVecNumRef):
-        return item.as_long()
+        return get_concrete_value(item)
     elif isinstance(item, BoolRef):
         simplified = simplify(item)
         if is_false(simplified):
@@ -82,7 +84,7 @@ def get_concrete_int(item):
         else:
             raise ValueError("Symbolic boolref encountered")
 
-    return simplify(item).as_long()
+    return get_concrete_value(simplify(item))
 
 
 def concrete_int_from_bytes(_bytes, start_index):
@@ -102,7 +104,7 @@ def concrete_int_to_bytes(val):
     if type(val) == int:
         return val.to_bytes(32, byteorder='big')
 
-    return (simplify(val).as_long()).to_bytes(32, byteorder='big')
+    return get_concrete_value(simplify(val)).to_bytes(32, byteorder='big')
 
 
 def bytearray_to_int(arr):

--- a/mythril/laser/ethereum/util.py
+++ b/mythril/laser/ethereum/util.py
@@ -73,7 +73,7 @@ def pop_bitvec(state):
 def get_concrete_int(item):
     if isinstance(item, int):
         return item
-    elif isinstance(item, BitVecNumRef):
+    elif is_bv_value(item):
         return get_concrete_value(item)
     elif is_bool(item):
         simplified = simplify(item)

--- a/mythril/laser/ethereum/util.py
+++ b/mythril/laser/ethereum/util.py
@@ -1,10 +1,11 @@
 import re
-from z3 import *
 import logging
 
 import sha3 as _sha3
 
-from mythril.laser.ethereum.smt_wrapper import get_concrete_value, simplify
+from mythril.laser.ethereum.smt_wrapper import \
+    get_concrete_value, simplify, is_bool, is_bv_value, is_true, is_false, \
+    If, BitVecVal
 
 
 TT256 = 2 ** 256

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ requests
 rlp>=1.0.1
 transaction>=2.2.1
 z3-solver>=4.5
+
+-e git+https://github.com/hzzhang/pysmt.git@hzzhang/props#egg=pysmt

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,10 @@ setup(
         'persistent>=4.2.0'
     ],
 
+    dependency_links=[
+        'git+https://github.com/hzzhang/pysmt.git@hzzhang/props#egg=pysmt',
+    ],
+
     tests_require=[
         'pytest>=3.6.0',
         'pytest_mock',

--- a/tests/laser/state/storage_test.py
+++ b/tests/laser/state/storage_test.py
@@ -1,6 +1,6 @@
 import pytest
 from mythril.laser.ethereum.state import Storage
-from z3 import is_expr
+from mythril.laser.ethereum.smt_wrapper import is_expr
 
 storage_uninitialized_test_data = [
     ({}, 1),

--- a/tests/laser/state/storage_test.py
+++ b/tests/laser/state/storage_test.py
@@ -1,6 +1,6 @@
 import pytest
 from mythril.laser.ethereum.state import Storage
-from z3 import ExprRef
+from z3 import is_expr
 
 storage_uninitialized_test_data = [
     ({}, 1),
@@ -32,7 +32,7 @@ def test_symbolic_storage_uninitialized_index(initial_storage, key):
     value = storage[key]
 
     # Assert
-    assert isinstance(value, ExprRef)
+    assert is_expr(value)
 
 
 def test_storage_set_item():

--- a/tests/laser/test_pysmt.py
+++ b/tests/laser/test_pysmt.py
@@ -1,0 +1,19 @@
+from pysmt.shortcuts import reset_env, get_env, Symbol
+from pysmt.typing import BVType
+
+
+def test_bv_prop():
+    reset_env()
+    get_env().enable_infix_notation = True
+
+    # Check if a modified pySMT which supports attaching arbitrary
+    # properties to pySMT FNode is used.
+
+    x = Symbol("x", BVType(256))
+    x.set_prop("tainted", True)
+    assert (x.get_prop("tainted") == True)
+
+    y = x + x
+    if x.get_prop("tainted"):
+        y.set_prop("tainted", True)
+    assert (y.get_prop("tainted") == True)

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -2,7 +2,7 @@ import pytest
 from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool, is_bv_value, is_expr
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    Eq, Neq
+    Eq, Neq, SLT, SGT
 
 
 def test_get_concrete_value_succ():
@@ -63,3 +63,37 @@ def test_Neq():
 def test_Neq_type_error():
     with pytest.raises(Exception):
         Neq(BitVecVal(0x1, 256), "x")
+
+
+def test_SLT():
+    operands = [BitVecVal(0x1, 256), 0x1, True]
+
+    lhs = operands[0]
+    for rhs in operands:
+        SLT(lhs, rhs)
+
+    rhs = operands[0]
+    for lhs in operands:
+        SLT(lhs, rhs)
+
+
+def test_SLT_type_error():
+    with pytest.raises(TypeError):
+        SLT(0x0, 0x1)
+
+
+def test_SGT():
+    operands = [BitVecVal(0x1, 256), 0x1, True]
+
+    lhs = operands[0]
+    for rhs in operands:
+        SGT(lhs, rhs)
+
+    rhs = operands[0]
+    for lhs in operands:
+        SGT(lhs, rhs)
+
+
+def test_SGT_type_error():
+    with pytest.raises(TypeError):
+        SGT(0x0, 0x1)

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -1,5 +1,5 @@
 import pytest
-from z3 import BitVec, BitVecVal
+from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value
 
@@ -19,3 +19,11 @@ def test_get_concrete_value_of_bv():
 def test_get_concrete_value_of_int():
     with pytest.raises(NotConcreteValueError):
         get_concrete_value(10)
+
+
+def test_is_bool():
+    assert (is_bool(BoolVal(False)))
+    assert (not is_bool(BitVec("x", 256)))
+    assert (not is_bool(IntVal(1)))
+    assert (not is_bool(True))
+    assert (not is_bool(1))

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -1,76 +1,86 @@
 import pytest
-from z3 import BoolVal, IntVal
+
+from pysmt.shortcuts import \
+    reset_env, get_env, Bool, Int
+
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
     BitVec, BitVecVal, Concat, Extract, \
     Eq, Neq, SLT, SGT, ULT, UGT, UDiv, SDiv, URem, SRem, \
     Not, And, Or, \
     SimplificationError, \
-    is_expr, is_bv_value, is_bv, is_bool, is_true, is_false
+    is_expr, is_bv_value, is_bv, is_bool, is_true, is_false, \
+    Result, solve, Solver
 from mythril.laser.ethereum.smt_wrapper import simplify as simplify_wrapper
 
 
-def test_get_concrete_value_succ():
+@pytest.fixture
+def reset_pysmt_env():
+    reset_env()
+    get_env().enable_infix_notation = True
+
+
+def test_get_concrete_value_succ(reset_pysmt_env):
     x = BitVecVal(0x100, 256)
     v = get_concrete_value(x)
     assert (v == 0x100)
 
 
-def test_get_concrete_value_of_bv():
+def test_get_concrete_value_of_bv(reset_pysmt_env):
     x = BitVec("x", 256)
     with pytest.raises(NotConcreteValueError):
         get_concrete_value(x)
 
 
-def test_get_concrete_value_of_int():
+def test_get_concrete_value_of_int(reset_pysmt_env):
     with pytest.raises(NotConcreteValueError):
         get_concrete_value(10)
 
 
-def test_is_bool():
-    assert (is_bool(BoolVal(False)))
+def test_is_bool(reset_pysmt_env):
+    assert (is_bool(Bool(False)))
     assert (not is_bool(BitVec("x", 256)))
-    assert (not is_bool(IntVal(1)))
+    assert (not is_bool(Int(1)))
     assert (not is_bool(True))
     assert (not is_bool(1))
 
 
-def test_is_bv_value():
+def test_is_bv_value(reset_pysmt_env):
     assert (is_bv_value(BitVecVal(0x100, 256)))
     assert (not is_bv_value(BitVec("x", 256)))
-    assert (not is_bv_value(IntVal(0x100)))
+    assert (not is_bv_value(Int(0x100)))
     assert (not is_bv_value(0x100))
 
 
-def test_is_expr():
+def test_is_expr(reset_pysmt_env):
     assert (is_expr(BitVecVal(0x100, 256)))
     assert (is_expr(BitVec("x", 256)))
     assert (not is_expr(0x100))
 
 
-def test_Eq():
-    operands = [BitVecVal(0x1, 256), IntVal(0x1), BoolVal(False), 0x1, True]
+def test_Eq(reset_pysmt_env):
+    operands = [BitVecVal(0x1, 256), Int(0x1), Bool(False), 0x1, True]
     for lhs, rhs in zip(operands, operands):
         Eq(lhs, rhs)
 
 
-def test_Eq_type_error():
+def test_Eq_type_error(reset_pysmt_env):
     with pytest.raises(Exception):
         Eq(BitVecVal(0x1, 256), "x")
 
 
-def test_Neq():
-    operands = [BitVecVal(0x1, 256), IntVal(0x1), BoolVal(False), 0x1, True]
+def test_Neq(reset_pysmt_env):
+    operands = [BitVecVal(0x1, 256), Int(0x1), Bool(False), 0x1, True]
     for lhs, rhs in zip(operands, operands):
         Neq(lhs, rhs)
 
 
-def test_Neq_type_error():
+def test_Neq_type_error(reset_pysmt_env):
     with pytest.raises(Exception):
         Neq(BitVecVal(0x1, 256), "x")
 
 
-def test_SLT():
+def test_SLT(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     lhs = operands[0]
@@ -82,12 +92,12 @@ def test_SLT():
         SLT(lhs, rhs)
 
 
-def test_SLT_type_error():
+def test_SLT_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         SLT(0x0, 0x1)
 
 
-def test_SGT():
+def test_SGT(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     lhs = operands[0]
@@ -99,12 +109,12 @@ def test_SGT():
         SGT(lhs, rhs)
 
 
-def test_SGT_type_error():
+def test_SGT_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         SGT(0x0, 0x1)
 
 
-def test_SDiv():
+def test_SDiv(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     dividend = operands[0]
@@ -116,73 +126,73 @@ def test_SDiv():
         SDiv(dividend, divisor)
 
 
-def test_SDiv_type_error():
+def test_SDiv_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         SDiv(0x1, 0x2)
 
 
-def test_simplify():
+def test_simplify(reset_pysmt_env):
     simpl = simplify_wrapper(BitVecVal(0x10, 256) + BitVecVal(0x20, 256))
     assert (get_concrete_value(simpl) == 0x30)
 
 
-def test_simplify_error():
+def test_simplify_error(reset_pysmt_env):
     with pytest.raises(SimplificationError):
         simplify_wrapper(1 + 1 == 2)
 
 
-def test_is_bv():
+def test_is_bv(reset_pysmt_env):
     assert (is_bv(BitVec("x", 256)))
     assert (is_bv(BitVecVal(0x100, 256)))
     assert (is_bv(BitVec("x", 256) + BitVecVal(0x100, 256)))
     assert (is_bv(BitVec("x", 256) + 0x100))
-    assert (not is_bv(IntVal(0x100)))
-    assert (not is_bv(BoolVal(False)))
+    assert (not is_bv(Int(0x100)))
+    assert (not is_bv(Bool(False)))
     assert (not is_bv(0x100))
     assert (not is_bv(False))
 
 
-def test_is_true():
-    assert (is_true(BoolVal(True)))
+def test_is_true(reset_pysmt_env):
+    assert (is_true(Bool(True)))
     assert (not is_true(True))
 
 
-def test_is_false():
-    assert (is_false(BoolVal(False)))
+def test_is_false(reset_pysmt_env):
+    assert (is_false(Bool(False)))
     assert (not is_false(False))
 
 
-def test_Not():
-    Not(BoolVal(False))
+def test_Not(reset_pysmt_env):
+    Not(Bool(False))
     Not(False)
 
 
-def test_Concat():
+def test_Concat(reset_pysmt_env):
     bv0 = BitVecVal(0xffff, 16)
     bv1 = BitVecVal(0xeeee, 16)
     bv = Concat(bv0, bv1)
     assert (get_concrete_value(simplify_wrapper(bv)) == 0xffffeeee)
 
 
-def test_Extract():
+def test_Extract(reset_pysmt_env):
     bv0 = BitVecVal(0xffffeeee, 32)
     bv = Extract(31, 16, bv0)
     assert (get_concrete_value(simplify_wrapper(bv)) == 0xffff)
 
 
-def test_And():
-    operands = [BoolVal(True), True]
+def test_And(reset_pysmt_env):
+    operands = [Bool(True), True]
     for lhs, rhs in zip(operands, operands):
         And(lhs, rhs)
 
 
-def test_Or():
-    operands = [BoolVal(True), True]
+def test_Or(reset_pysmt_env):
+    operands = [Bool(True), True]
     for lhs, rhs in zip(operands, operands):
         Or(lhs, rhs)
 
 
-def test_ULT():
+def test_ULT(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     lhs = operands[0]
@@ -194,12 +204,12 @@ def test_ULT():
         ULT(lhs, rhs)
 
 
-def test_ULT_type_error():
+def test_ULT_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         ULT(0x2, 0x1)
 
 
-def test_UGT():
+def test_UGT(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     lhs = operands[0]
@@ -211,12 +221,12 @@ def test_UGT():
         UGT(lhs, rhs)
 
 
-def test_UGT_type_error():
+def test_UGT_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         UGT(0x2, 0x1)
 
 
-def test_UDiv():
+def test_UDiv(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     dividend = operands[0]
@@ -228,12 +238,12 @@ def test_UDiv():
         UDiv(dividend, divisor)
 
 
-def test_UDiv_type_error():
+def test_UDiv_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         UDiv(0x1, 0x2)
 
 
-def test_URem():
+def test_URem(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     dividend = operands[0]
@@ -245,12 +255,12 @@ def test_URem():
         URem(dividend, divisor)
 
 
-def test_URem_type_error():
+def test_URem_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         URem(0x1, 0x2)
 
 
-def test_SRem():
+def test_SRem(reset_pysmt_env):
     operands = [BitVecVal(0x1, 256), 0x1, True]
 
     dividend = operands[0]
@@ -262,6 +272,36 @@ def test_SRem():
         SRem(dividend, divisor)
 
 
-def test_SRem_type_error():
+def test_SRem_type_error(reset_pysmt_env):
     with pytest.raises(TypeError):
         SRem(0x1, 0x2)
+
+
+def test_solve(reset_pysmt_env):
+    x = BitVec("x", 256)
+    y = BitVec("y", 256)
+    z = BitVec("z", 256)
+
+    s = Solver()
+    s.push()
+    s.add_assertion(ULT(x, y))  # x < y
+    s.add_assertion(ULT(y, z))  # y < z
+    result = solve(s)
+    s.pop()
+    assert (result == Result.sat)
+
+    s.push()
+    s.add_assertion(ULT(x, y))  # x < y
+    s.add_assertion(ULT(y, z))  # y < z
+    s.add_assertion(ULT(z, x))  # z < x
+    result = solve(s)
+    s.pop()
+    assert (result == Result.unsat)
+
+    s = Solver(timeout=1)
+    s.add_assertion(Eq(x * x + y * y, z * z)) # x^2 + y^2 = z^2
+    s.add_assertion(ULT(0, x))                # x > 0
+    s.add_assertion(ULT(0, y))                # y > 0
+    s.add_assertion(ULT(0, z))                # z > 0
+    result = solve(s)
+    assert (result == Result.unknown)

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -1,5 +1,5 @@
 import pytest
-from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool
+from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool, is_bv_value
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value
 
@@ -27,3 +27,10 @@ def test_is_bool():
     assert (not is_bool(IntVal(1)))
     assert (not is_bool(True))
     assert (not is_bool(1))
+
+
+def test_is_bv_value():
+    assert (is_bv_value(BitVecVal(0x100, 256)))
+    assert (not is_bv_value(BitVec("x", 256)))
+    assert (not is_bv_value(IntVal(0x100)))
+    assert (not is_bv_value(0x100))

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -1,5 +1,5 @@
 import pytest
-from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool, is_bv_value
+from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool, is_bv_value, is_expr
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value
 
@@ -34,3 +34,9 @@ def test_is_bv_value():
     assert (not is_bv_value(BitVec("x", 256)))
     assert (not is_bv_value(IntVal(0x100)))
     assert (not is_bv_value(0x100))
+
+
+def test_is_expr():
+    assert (is_expr(BitVecVal(0x100, 256)))
+    assert (is_expr(BitVec("x", 256)))
+    assert (not is_expr(0x100))

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -2,7 +2,7 @@ import pytest
 from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool, is_bv_value, is_expr
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    Eq, Neq, SLT, SGT
+    Eq, Neq, SLT, SGT, SDiv
 
 
 def test_get_concrete_value_succ():
@@ -97,3 +97,20 @@ def test_SGT():
 def test_SGT_type_error():
     with pytest.raises(TypeError):
         SGT(0x0, 0x1)
+
+
+def test_SDiv():
+    operands = [BitVecVal(0x1, 256), 0x1, True]
+
+    dividend = operands[0]
+    for divisor in operands:
+        SDiv(dividend, divisor)
+
+    divisor = operands[0]
+    for dividend in operands:
+        SDiv(dividend, divisor)
+
+
+def test_SDiv_type_error():
+    with pytest.raises(TypeError):
+        SDiv(0x1, 0x2)

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -1,7 +1,8 @@
 import pytest
 from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool, is_bv_value, is_expr
 from mythril.laser.ethereum.smt_wrapper import \
-    NotConcreteValueError, get_concrete_value
+    NotConcreteValueError, get_concrete_value, \
+    Eq, Neq
 
 
 def test_get_concrete_value_succ():
@@ -40,3 +41,25 @@ def test_is_expr():
     assert (is_expr(BitVecVal(0x100, 256)))
     assert (is_expr(BitVec("x", 256)))
     assert (not is_expr(0x100))
+
+
+def test_Eq():
+    operands = [BitVecVal(0x1, 256), IntVal(0x1), BoolVal(False), 0x1, True]
+    for lhs, rhs in zip(operands, operands):
+        Eq(lhs, rhs)
+
+
+def test_Eq_type_error():
+    with pytest.raises(Exception):
+        Eq(BitVecVal(0x1, 256), "x")
+
+
+def test_Neq():
+    operands = [BitVecVal(0x1, 256), IntVal(0x1), BoolVal(False), 0x1, True]
+    for lhs, rhs in zip(operands, operands):
+        Neq(lhs, rhs)
+
+
+def test_Neq_type_error():
+    with pytest.raises(Exception):
+        Neq(BitVecVal(0x1, 256), "x")

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -1,0 +1,21 @@
+import pytest
+from z3 import BitVec, BitVecVal
+from mythril.laser.ethereum.smt_wrapper import \
+    NotConcreteValueError, get_concrete_value
+
+
+def test_get_concrete_value_succ():
+    x = BitVecVal(0x100, 256)
+    v = get_concrete_value(x)
+    assert (v == 0x100)
+
+
+def test_get_concrete_value_of_bv():
+    x = BitVec("x", 256)
+    with pytest.raises(NotConcreteValueError):
+        get_concrete_value(x)
+
+
+def test_get_concrete_value_of_int():
+    with pytest.raises(NotConcreteValueError):
+        get_concrete_value(10)

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -2,7 +2,9 @@ import pytest
 from z3 import BitVec, BitVecVal, BoolVal, IntVal, is_bool, is_bv_value, is_expr
 from mythril.laser.ethereum.smt_wrapper import \
     NotConcreteValueError, get_concrete_value, \
-    Eq, Neq, SLT, SGT, SDiv
+    Eq, Neq, SLT, SGT, SDiv, \
+    SimplificationError
+from mythril.laser.ethereum.smt_wrapper import simplify as simplify_wrapper
 
 
 def test_get_concrete_value_succ():
@@ -114,3 +116,13 @@ def test_SDiv():
 def test_SDiv_type_error():
     with pytest.raises(TypeError):
         SDiv(0x1, 0x2)
+
+
+def test_simplify():
+    simpl = simplify_wrapper(BitVecVal(0x10, 256) + BitVecVal(0x20, 256))
+    assert (get_concrete_value(simpl) == 0x30)
+
+
+def test_simplify_error():
+    with pytest.raises(SimplificationError):
+        simplify_wrapper(1 + 1 == 2)

--- a/tests/laser/test_smt_wrapper.py
+++ b/tests/laser/test_smt_wrapper.py
@@ -81,7 +81,7 @@ def test_Neq_type_error(reset_pysmt_env):
 
 
 def test_SLT(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     lhs = operands[0]
     for rhs in operands:
@@ -98,7 +98,7 @@ def test_SLT_type_error(reset_pysmt_env):
 
 
 def test_SGT(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     lhs = operands[0]
     for rhs in operands:
@@ -115,7 +115,7 @@ def test_SGT_type_error(reset_pysmt_env):
 
 
 def test_SDiv(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     dividend = operands[0]
     for divisor in operands:
@@ -193,7 +193,7 @@ def test_Or(reset_pysmt_env):
 
 
 def test_ULT(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     lhs = operands[0]
     for rhs in operands:
@@ -210,7 +210,7 @@ def test_ULT_type_error(reset_pysmt_env):
 
 
 def test_UGT(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     lhs = operands[0]
     for rhs in operands:
@@ -227,7 +227,7 @@ def test_UGT_type_error(reset_pysmt_env):
 
 
 def test_UDiv(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     dividend = operands[0]
     for divisor in operands:
@@ -244,7 +244,7 @@ def test_UDiv_type_error(reset_pysmt_env):
 
 
 def test_URem(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     dividend = operands[0]
     for divisor in operands:
@@ -261,7 +261,7 @@ def test_URem_type_error(reset_pysmt_env):
 
 
 def test_SRem(reset_pysmt_env):
-    operands = [BitVecVal(0x1, 256), 0x1, True]
+    operands = [BitVecVal(0x1, 256), Int(0x1), 0x1, Bool(True), True]
 
     dividend = operands[0]
     for divisor in operands:

--- a/tests/svm_test.py
+++ b/tests/svm_test.py
@@ -11,8 +11,6 @@ from tests import *
 
 class LaserEncoder(json.JSONEncoder):
     def default(self, o):
-        if getattr(o, "__module__", None) == "z3.z3":
-            return str(o)
         return str(o)
 
 


### PR DESCRIPTION
This patch series is to address issue #533. It replaces the use of Z3 in Mythril by [pySMT](https://pysmt.readthedocs.io/en/latest/) that provides a unified APIs for SMT-lib compatible constraint solvers (including Z3, CVC4, Yices, etc.).

In addition, a modified [pySMT](https://github.com/hzzhang/pysmt/tree/hzzhang/props) is used to support attaching arbitrary properties to pySMT FNode (which represents expressions, formulas and constraints akin to Z3 ExprRef), so that we can, for example, add the taint information to symbols in the future. You can refer to `tests/laser/test_pysmt.py` for a simple example.

All tests from `all_tests.sh` are passed locally when the Z3 solver is used. Other solvers have not been tested, because they may require additional adjustment, especially for configurations of constraint solving, e.g., the timeout may not be supported by every solver and may be configured in a solver-specific way which has not been unified by pySMT).

This patch series is organized as below.
* Patch 01-02 fix/cleanup the existing code and are not quite relevant to this patch series.
* Patch 03-11 replaces most uses of Z3 APIs by a set of wrapper functions, so that when switching to pySMT APIs, we only need to reimplement wrappers to use pySMT APIs.
* Patch 12-17 reimplement above wrappers on pySMT APIs and fix several issues after the API switch.
