### PR TITLE
Problem: truffle project analysis ignores --solc-args

### DIFF
--- a/mythril/support/truffle.py
+++ b/mythril/support/truffle.py
@@ -40,7 +40,7 @@ def analyze_truffle_project(sigs, args):
             if len(bytecode) < 4:
                 continue
 
-            sigs.import_from_solidity_source(contractdata['sourcePath'])
+            sigs.import_from_solidity_source(contractdata['sourcePath'], solc_args=args.solc_args)
             sigs.write()
 
             ethcontract = ETHContract(bytecode, name=name)


### PR DESCRIPTION
This prevents passing custom `solc` arguments which is important in some
cases (for example, `--allow-paths` is a very useful option)

Solution: pass solc_args through