### PR TITLE
Problem: docker build times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:bionic
 
-COPY . /opt/mythril
-
 RUN apt-get update \
   && apt-get install -y \
      build-essential \
@@ -18,8 +16,11 @@ RUN apt-get update \
      python3-dev \
      pandoc \
      git \
-  && ln -s /usr/bin/python3 /usr/local/bin/python \
-  && cd /opt/mythril \
+  && ln -s /usr/bin/python3 /usr/local/bin/python
+
+COPY . /opt/mythril
+
+RUN cd /opt/mythril \
   && pip3 install -r requirements.txt \
   && python setup.py install
 


### PR DESCRIPTION
Currenlty, every time a docker container is rebuilt for updated source
code of the package, it'll start from scratch. This means it will not
reuse layers with existing Python, solc, etc. installation.

Solution: install Python first, copy source code after

This allows to reuse the base layer.