### PR TITLE
Precopy requirements.txt in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update \
      git \
   && ln -s /usr/bin/python3 /usr/local/bin/python
 
-COPY . /opt/mythril
+
+COPY ./requirements.txt /opt/mythril/requirements.txt
 
 RUN cd /opt/mythril \
   && pip3 install -r requirements.txt \
@@ -28,5 +29,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.en
 ENV LC_ALL en_US.UTF-8
+
+COPY . /opt/mythril
 
 ENTRYPOINT ["/usr/local/bin/myth"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update \
   && ln -s /usr/bin/python3 /usr/local/bin/python
 
 COPY ./setup.py /opt/mythril/setup.py
-COPY ./Pipfile /opt/mythril/Pipfile
 COPY ./requirements.txt /opt/mythril/requirements.txt
 
 RUN cd /opt/mythril \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update \
      git \
   && ln -s /usr/bin/python3 /usr/local/bin/python
 
-
+COPY ./setup.py /opt/mythril/setup.py
+COPY ./Pipfile /opt/mythril/Pipfile
 COPY ./requirements.txt /opt/mythril/requirements.txt
 
 RUN cd /opt/mythril \


### PR DESCRIPTION
Commit 0619cf2612ac9ae5048520ee0c078eef7e96808b made it better already, but precopying requirements.txt prevents the complete pip3 install to execute whenever a file changes.