### PR TITLE
Fix docker build: Mythril module installation needs source code copied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
   && ln -s /usr/bin/python3 /usr/local/bin/python
 
 COPY ./setup.py /opt/mythril/setup.py
+COPY ./mythril/version.py /opt/mythril/mythril/version.py
 COPY ./requirements.txt /opt/mythril/requirements.txt
 
 RUN cd /opt/mythril \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,10 @@ RUN apt-get update \
      git \
   && ln -s /usr/bin/python3 /usr/local/bin/python
 
-COPY ./setup.py /opt/mythril/setup.py
-COPY ./mythril/version.py /opt/mythril/mythril/version.py
 COPY ./requirements.txt /opt/mythril/requirements.txt
 
 RUN cd /opt/mythril \
-  && pip3 install -r requirements.txt \
-  && python setup.py install
+  && pip3 install -r requirements.txt
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -32,5 +29,7 @@ ENV LANGUAGE en_US.en
 ENV LC_ALL en_US.UTF-8
 
 COPY . /opt/mythril
+RUN cd /opt/mythril \
+  && python setup.py install
 
 ENTRYPOINT ["/usr/local/bin/myth"]


### PR DESCRIPTION
Docker build failed after https://github.com/ConsenSys/mythril/pull/585 since the mythril module can't be installed without the source code folder. 
Fixed by separating the pip3 installs from the mythril module installation.