### PR TITLE
Add Useful Suggestion to Solidity Version CompilerErrors

### DIFF
--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -12,7 +12,6 @@ import os
 import sys
 
 import coloredlogs
-import re
 import traceback
 
 import mythril.support.signatures as sigs
@@ -623,30 +622,6 @@ def contract_hash_to_address(args: Namespace):
     sys.exit()
 
 
-def is_solv_mismatch_error(error_message: str):
-    """
-    checks an error message to determine if related to solidity version mismatch
-    :param error_message:
-    :return: Boolean
-    """
-
-    return True if "Error: Source file requires different compiler version" in error_message else False
-
-
-def extract_compatible_solv(error_message: str):
-    """
-    extracts the desired solidity version from the CompilerError message
-    :param error_message:
-    :return: String, (ie. 0.5.10)
-    """
-
-    # this corresponds to the line "pragma solidity <solv>..."
-    solv_definition = error_message.split("\n")[-3]
-    # get the version number
-    solv_match = re.search(r'[0-9]+\.[0-9]+\.[0-9]+', solv_definition)
-    return "<version_number>" if solv_match is None else solv_match[0]
-
-
 def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
     """
     Parses the arguments
@@ -706,14 +681,7 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
             disassembler=disassembler, address=address, parser=parser, args=args
         )
     except CriticalError as ce:
-        # Extract error message
-        error_msg = str(ce)
-        # Check if error is related to solv mismatch
-        if is_solv_mismatch_error(error_msg):
-            # Inform users of potential fix
-            error_msg = error_msg + "\nSolidityVersionMismatch: Try adding the option \"--solv " + extract_compatible_solv(error_msg) + "\"\n"
-
-        exit_with_error(args.__dict__.get("outform", "text"), error_msg)
+        exit_with_error(args.__dict__.get("outform", "text"), str(ce))
     except Exception:
         exit_with_error(args.__dict__.get("outform", "text"), traceback.format_exc())
 

--- a/mythril/mythril/mythril_disassembler.py
+++ b/mythril/mythril/mythril_disassembler.py
@@ -186,7 +186,6 @@ class MythrilDisassembler:
             except FileNotFoundError:
                 raise CriticalError("Input file not found: " + file)
             except CompilerError as e:
-                # Extract error message as string
                 error_msg = str(e)
                 # Check if error is related to solidity version mismatch
                 if (
@@ -197,11 +196,9 @@ class MythrilDisassembler:
                     solv_pragma_line = error_msg.split("\n")[-3].split("//")[0]
                     # Grab solidity version from relevant line
                     solv_match = re.findall(r"[0-9]+\.[0-9]+\.[0-9]+", solv_pragma_line)
-                    # Check if single match exists, else offer generic suggestion
                     error_suggestion = (
                         "<version_number>" if len(solv_match) != 1 else solv_match[0]
                     )
-                    # Give helpful tip
                     error_msg = (
                         error_msg
                         + '\nSolidityVersionMismatch: Try adding the option "--solv '

--- a/mythril/mythril/mythril_disassembler.py
+++ b/mythril/mythril/mythril_disassembler.py
@@ -186,7 +186,30 @@ class MythrilDisassembler:
             except FileNotFoundError:
                 raise CriticalError("Input file not found: " + file)
             except CompilerError as e:
-                raise CriticalError(e)
+                # Extract error message as string
+                error_msg = str(e)
+                # Check if error is related to solidity version mismatch
+                if (
+                    "Error: Source file requires different compiler version"
+                    in error_msg
+                ):
+                    # Grab relevant line "pragma solidity <solv>...", excluding any comments
+                    solv_pragma_line = error_msg.split("\n")[-3].split("//")[0]
+                    # Grab solidity version from relevant line
+                    solv_match = re.findall(r"[0-9]+\.[0-9]+\.[0-9]+", solv_pragma_line)
+                    # Check if single match exists, else offer generic suggestion
+                    error_suggestion = (
+                        "<version_number>" if len(solv_match) != 1 else solv_match[0]
+                    )
+                    # Give helpful tip
+                    error_msg = (
+                        error_msg
+                        + '\nSolidityVersionMismatch: Try adding the option "--solv '
+                        + error_suggestion
+                        + '"\n'
+                    )
+
+                raise CriticalError(error_msg)
             except NoContractFoundError:
                 log.error(
                     "The file " + file + " does not contain a compilable contract."


### PR DESCRIPTION
Modified mythril_disassembler.py to add useful suggestion when CompilerError is invoked by a solidity version mismatch.