### PR TITLE
Add function names to report output

### DIFF
--- a/mythril/analysis/report.py
+++ b/mythril/analysis/report.py
@@ -165,11 +165,15 @@ class Issue:
 
         for step in self.transaction_sequence["steps"]:
             _hash = step["input"][:10]
-            sig = signatures.get(_hash)
 
-            if len(sig) > 0:
-                step["name"] = sig[0]
-            else:
+            try:
+                sig = signatures.get(_hash)
+
+                if len(sig) > 0:
+                    step["name"] = sig[0]
+                else:
+                    step["name"] = "unknown"
+            except ValueError:
                 step["name"] = "unknown"
 
 

--- a/mythril/analysis/templates/report_as_markdown.jinja2
+++ b/mythril/analysis/templates/report_as_markdown.jinja2
@@ -32,7 +32,7 @@ In file: {{ issue.filename }}:{{ issue.lineno }}
 {% if step == issue.tx_sequence.steps[0] and step.input != "0x" and step.origin == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}
 Caller: [CREATOR], data: [CONTRACT CREATION], value: {{ step.value }}
 {% else %}
-Caller: {% if step.origin == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}[CREATOR]{% elif step.origin == "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" %}[ATTACKER]{% else %}[SOMEGUY]{% endif %}, data: {{ step.input }}, value: {{ step.value }}
+Caller: {% if step.origin == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}[CREATOR]{% elif step.origin == "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" %}[ATTACKER]{% else %}[SOMEGUY]{% endif %}, function: {{ step.name }}, txdata: {{ step.input }}, value: {{ step.value }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/mythril/analysis/templates/report_as_text.jinja2
+++ b/mythril/analysis/templates/report_as_text.jinja2
@@ -25,7 +25,7 @@ Transaction Sequence:
 {% if step == issue.tx_sequence.steps[0] and step.input != "0x" and step.origin == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}
 Caller: [CREATOR], data: [CONTRACT CREATION], value: {{ step.value }}
 {% else %}
-Caller: {% if step.origin == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}[CREATOR]{% elif step.origin == "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" %}[ATTACKER]{% else %}[SOMEGUY]{% endif %}, data: {{ step.input }}, value: {{ step.value }}
+Caller: {% if step.origin == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}[CREATOR]{% elif step.origin == "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" %}[ATTACKER]{% else %}[SOMEGUY]{% endif %}, function: {{ step.name }}, txdata: {{ step.input }}, value: {{ step.value }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -84,10 +84,8 @@ def get_function_info(
     # Append with missing 0s at the beginning
     function_hash = "0x" + instruction_list[index]["argument"][2:].rjust(8, "0")
     function_names = signature_database.get(function_hash)
-    if len(function_names) > 1:
-        # In this case there was an ambiguous result
-        function_name = "[{}] (ambiguous)".format(", ".join(function_names))
-    elif len(function_names) == 1:
+
+    if len(function_names) > 0:
         function_name = function_names[0]
     else:
         function_name = "_function_" + function_hash


### PR DESCRIPTION
Adds function names to text and markdown reports:

```
$myth analyze token-with-backdoor.sol -t3
==== Exception State ====
SWC ID: 110
Severity: Low
Contract: Token
Function name: test_invariants()
PC address: 621
Estimated Gas Usage: 715 - 1000
A reachable exception has been detected.
It is possible to trigger an exception (opcode 0xfe). Exceptions can be caused by type errors, division by zero, out-of-bounds array access, or assert violations. Note that explicit `assert()` should only be used to check invariants. Use `require()` for regular input checking.
--------------------
In file: token-with-backdoor.sol:28

assert(balances[msg.sender] <= 1000)

--------------------
Transaction Sequence:

Caller: [CREATOR], data: [CONTRACT CREATION], value: 0x0
Caller: [CREATOR], function: airdrop(), txdata: 0x3884d635, value: 0x0
Caller: [CREATOR], function: backdoor(), txdata: 0x2665f77d, value: 0x0
Caller: [CREATOR], function: test_invariants(), txdata: 0xd3ba8448, value: 0x0
```