### PR TITLE
Load contracts from the blockchain by default

### DIFF
--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -350,7 +350,7 @@ def create_analyzer_parser(analyzer_parser: ArgumentParser):
         "--create-timeout",
         type=int,
         default=10,
-        help="The amount of seconds to spend on " "the initial contract creation",
+        help="The amount of seconds to spend on the initial contract creation",
     )
     options.add_argument(
         "-l",
@@ -360,8 +360,9 @@ def create_analyzer_parser(analyzer_parser: ArgumentParser):
     )
     options.add_argument(
         "--no-onchain-storage-access",
+        "--no-onchain-access",
         action="store_true",
-        help="turns off getting the data from onchain contracts",
+        help="turns off getting the data from onchain contracts (both loading storage and contract code)",
     )
 
     options.add_argument(
@@ -552,6 +553,7 @@ def execute_command(
             enable_iprof=args.enable_iprof,
             disable_dependency_pruning=args.disable_dependency_pruning,
             onchain_storage_access=not args.no_onchain_storage_access,
+            requires_dynld=not args.no_onchain_storage_access,
         )
 
         if not disassembler.contracts:


### PR DESCRIPTION
Hi !

First PR, I may not have done everything correctly. (Should I push to develop instead of master?)
Also I was not able to pass the full test suite (some truffle problems finding the right solc compiler…), but most tests passed, and the one that failed should be unrelated.

This is an opinionated choice that would change the default behavior of Mythril. I'm happy to make it an additional parameter to control only contract loading, if you prefer.

What I want is to be able to enable contract loading from the CLI, which is impossible now.

I kept the old parameter name so nothing breaks. It could be deprecated/removed at some point.