### PR TITLE
Print initial state in jinja

### DIFF
--- a/mythril/analysis/templates/report_as_markdown.jinja2
+++ b/mythril/analysis/templates/report_as_markdown.jinja2
@@ -26,6 +26,12 @@ In file: {{ issue.filename }}:{{ issue.lineno }}
 {% endif %}
 {% if issue.tx_sequence %}
 
+### Initial State:
+
+{% for key, value in issue.tx_sequence.initialState.accounts.items() %}
+Account: {% if key == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}[CREATOR]{% elif key == "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" %}[ATTACKER]{% else %}[SOMEGUY]{% endif %}, balance: {{value.balance}}, nonce:{{value.nonce}}, storage:{{value.storage}}
+{% endfor %}
+
 ### Transaction Sequence
 
 {% for step in issue.tx_sequence.steps %}

--- a/mythril/analysis/templates/report_as_text.jinja2
+++ b/mythril/analysis/templates/report_as_text.jinja2
@@ -19,6 +19,12 @@ In file: {{ issue.filename }}:{{ issue.lineno }}
 --------------------
 {% endif %}
 {% if issue.tx_sequence %}
+Initial State:
+
+{% for key, value in issue.tx_sequence.initialState.accounts.items() %}
+Account: {% if key == "0xaffeaffeaffeaffeaffeaffeaffeaffeaffeaffe" %}[CREATOR]{% elif key == "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" %}[ATTACKER]{% else %}[SOMEGUY]{% endif %}, balance: {{value.balance}}, nonce:{{value.nonce}}, storage:{{value.storage}}
+{% endfor %}
+
 Transaction Sequence:
 
 {% for step in issue.tx_sequence.steps %}


### PR DESCRIPTION
Updated jinja templates to reflect initialStates of transaction sequences. Should 'code' also be included as part of the initial state?