### PR TITLE
Fix for #1176: track what storage has been initialized. Load uninitialized storage once.

### DIFF
--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -4,7 +4,7 @@ This includes classes representing accounts and their storage.
 """
 import logging
 from copy import copy, deepcopy
-from typing import Any, Dict, Union, Tuple, cast
+from typing import Any, Dict, Union, Tuple, Set, cast
 
 
 from mythril.laser.smt import (
@@ -60,7 +60,7 @@ class Storage:
         self.printable_storage = {}  # type: Dict[BitVec, BitVec]
 
         self.dynld = dynamic_loader
-        self.storage_keys_loaded = set()
+        self.storage_keys_loaded = set()  # type: Set[int]
         self.address = address
 
     @staticmethod

--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -136,7 +136,8 @@ class Storage:
         if is_keccak_storage:
             key = self._sanitize(key.input_)
         storage[key] = value
-        self.storage_keys_loaded.add(int(key.value))
+        if key.symbolic is False:
+            self.storage_keys_loaded.add(int(key.value))
 
     def __deepcopy__(self, memodict=dict()):
         concrete = isinstance(self._standard_storage, K)

--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -79,8 +79,8 @@ class Storage:
         if (
             self.address
             and self.address.value != 0
-            and int(item.value) not in self.storage_keys_loaded
             and item.symbolic is False
+            and int(item.value) not in self.storage_keys_loaded
             and (self.dynld and self.dynld.storage_loading)
         ):
             try:


### PR DESCRIPTION
This should be the right fix for #1176 that does not introduce a regression (see #674 for a regression example)

Please triple check this code, I still don't know how to run integrations tests properly, and I feel like the default test suite is pretty "light" (it didn't catch a few errors I made). I tested on a few contracts but that's all.