### PR TITLE
Added support for solidity 0.5.x

### DIFF
--- a/mythril/__version__.py
+++ b/mythril/__version__.py
@@ -4,4 +4,4 @@ This file is suitable for sourcing inside POSIX shell, e.g. bash as well
 as for importing into Python.
 """
 
-__version__ = "v0.21.16"
+__version__ = "v0.21.17"

--- a/mythril/ethereum/util.py
+++ b/mythril/ethereum/util.py
@@ -130,13 +130,7 @@ def solc_exists(version):
         ]
     else:
         # we are using solc-x for the the 0.5 and higher
-        solc_binaries = [
-            os.path.join(
-                solcx.__path__[0],
-                "bin",
-                "solc-v" + version
-            )
-        ]
+        solc_binaries = [os.path.join(solcx.__path__[0], "bin", "solc-v" + version)]
 
     for solc_path in solc_binaries:
         if os.path.exists(solc_path):

--- a/mythril/ethereum/util.py
+++ b/mythril/ethereum/util.py
@@ -3,6 +3,7 @@ solc integration."""
 import binascii
 import json
 import os
+import solcx
 from pathlib import Path
 from subprocess import PIPE, Popen
 
@@ -117,16 +118,31 @@ def solc_exists(version):
     :param version:
     :return:
     """
-    solc_binaries = [
-        os.path.join(
-            os.environ.get("HOME", str(Path.home())),
-            ".py-solc/solc-v" + version,
-            "bin/solc",
-        )  # py-solc setup
-    ]
-    if version.startswith("0.5"):
-        # Temporary fix to support v0.5.x with Ubuntu PPA setup
-        solc_binaries.append("/usr/bin/solc")
+
+    solc_binaries = []
+    if version.startswith("0.4"):
+        solc_binaries = [
+            os.path.join(
+                os.environ.get("HOME", str(Path.home())),
+                ".py-solc/solc-v" + version,
+                "bin/solc",
+            )  # py-solc setup
+        ]
+    else:
+        # we are using solc-x for the the 0.5 and higher
+        solc_binaries = [
+            os.path.join(
+                solcx.__path__[0],
+                "bin",
+                "solc-v" + version
+            )
+        ]
+
     for solc_path in solc_binaries:
         if os.path.exists(solc_path):
             return solc_path
+
+    # Last resort is to use the system installation
+    default_binary = "/usr/bin/solc"
+    if os.path.exists(default_binary):
+        return default_binary

--- a/mythril/mythril/mythril_disassembler.py
+++ b/mythril/mythril/mythril_disassembler.py
@@ -63,7 +63,9 @@ class MythrilDisassembler:
             solc_binary = os.environ.get("SOLC") or "solc"
         else:
             solc_binary = util.solc_exists(version)
-            if solc_binary and solc_binary != util.solc_exists("default_ubuntu_version"):
+            if solc_binary and solc_binary != util.solc_exists(
+                "default_ubuntu_version"
+            ):
                 log.info("Given version is already installed")
             else:
                 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ mock
 persistent>=4.2.0
 plyvel
 py-flags
+py-solc-x
 py-solc
 pytest>=3.6.0
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ pytest-cov
 pytest_mock
 requests>=2.22.0
 rlp>=1.0.1
+semantic_version==2.8.1
 transaction>=2.2.1
 z3-solver>=4.8.5.0
 pysha3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ mock
 persistent>=4.2.0
 plyvel
 py-flags
-py-solc-x
+py-solc-x==0.6.0
 py-solc
 pytest>=3.6.0
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ REQUIRED = [
     "z3-solver>=4.8.5.0",
     "requests>=2.22.0",
     "py-solc",
+    "py-solc-x==0.6.0",
+    "semantic_version==2.8.1",
     "plyvel",
     "eth_abi==1.3.0",
     "eth-account>=0.1.0a2,<=0.3.0",

--- a/tests/native_test.py
+++ b/tests/native_test.py
@@ -76,6 +76,8 @@ class NativeTests(BaseTestCase):
     @staticmethod
     def runTest():
         """"""
+        # The solidity version (0.5.3 at the moment) should be kept in sync with
+        # pragma in ./tests/native_tests.sol
         disassembly = SolidityContract(
             "./tests/native_tests.sol",
             solc_binary=MythrilDisassembler._init_solc_binary("0.5.3"),

--- a/tests/native_tests.sol
+++ b/tests/native_tests.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.5.3;
 
 
 contract Caller {

--- a/tests/native_tests.sol
+++ b/tests/native_tests.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.3;
+pragma solidity ^0.5.0;
 
 
 contract Caller {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36
+envlist = py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Mythril relies on `py-solc` to install versions specified by the `--solv` parameter. Unfortunately, `py-solc` does not seem maintained and cannot install solc with versions 0.5.x. Thus, Mythril currently supports only the system solc installation for 0.5.x. 

This PR adds `py-solc-x` dependency which is used for versions other than 0.4.x. For 0.4.x, handling by `py-solc` is preserved, because `py-solc-x` declares incompatibility of 0.4.x installations with OSX.

This should solve Mythril's dynamic support for 0.5.x that is reference e.g. in ethereum/py-solc#63, andindirectly also in #1217.

Tested with Docker as follows:

```
docker build .
docker run -v /tmp:/tmp 3ff13f1e1c8b analyze /tmp/contract.sol --solv 0.5.10 -o jsonv2
docker run -v /tmp:/tmp 3ff13f1e1c8b analyze /tmp/contract.sol --solv 0.4.24 -o jsonv2
```