### PR TITLE
Added returning global state to SIGNEXTEND opcode.

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -628,7 +628,9 @@ class Instruction:
         except TypeError:
             log.debug("Unsupported symbolic argument for SIGNEXTEND")
             mstate.stack.append(
-                global_state.new_bitvec("SIGNEXTEND({},{})".format(s0, hash(s1)), 256)
+                global_state.new_bitvec(
+                    "SIGNEXTEND({},{})".format(hash(s0), hash(s1)), 256
+                )
             )
             return [global_state]
 

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -619,23 +619,24 @@ class Instruction:
         :param global_state:
         :return:
         """
-        state = global_state.mstate
-        s0, s1 = state.stack.pop(), state.stack.pop()
+        mstate = global_state.mstate
+        s0, s1 = mstate.stack.pop(), mstate.stack.pop()
 
         try:
             s0 = util.get_concrete_int(s0)
             s1 = util.get_concrete_int(s1)
         except TypeError:
-            return []
+            mstate.stack.append(s1)
+            return [global_state]
 
         if s0 <= 31:
             testbit = s0 * 8 + 7
             if s1 & (1 << testbit):
-                state.stack.append(s1 | (TT256 - (1 << testbit)))
+                mstate.stack.append(s1 | (TT256 - (1 << testbit)))
             else:
-                state.stack.append(s1 & ((1 << testbit) - 1))
+                mstate.stack.append(s1 & ((1 << testbit) - 1))
         else:
-            state.stack.append(s1)
+            mstate.stack.append(s1)
 
         return [global_state]
 

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -626,7 +626,10 @@ class Instruction:
             s0 = util.get_concrete_int(s0)
             s1 = util.get_concrete_int(s1)
         except TypeError:
-            mstate.stack.append(s1)  # TODO: push appropriate value to stack
+            log.debug("Unsupported symbolic argument for SIGNEXTEND")
+            mstate.stack.append(
+                global_state.new_bitvec("SIGNEXTEND({},{})".format(s0, hash(s1)), 256)
+            )
             return [global_state]
 
         if s0 <= 31:

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -626,7 +626,7 @@ class Instruction:
             s0 = util.get_concrete_int(s0)
             s1 = util.get_concrete_int(s1)
         except TypeError:
-            mstate.stack.append(s1)
+            mstate.stack.append(s1)  # TODO: push appropriate value to stack
             return [global_state]
 
         if s0 <= 31:


### PR DESCRIPTION
When arguments to SIGNEXTEND are symbolic, a type error is thrown but no global_state is returned.