### PR TITLE
New algo for creating loop counter keys

### DIFF
--- a/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
+++ b/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
@@ -14,7 +14,7 @@ class JumpdestCountAnnotation(StateAnnotation):
     """State annotation that counts the number of jumps per destination."""
 
     def __init__(self) -> None:
-        self._reached_count = {}  # type: Dict[str, int]
+        self._reached_count = {}  # type: Dict[int, int]
         self.trace = []  # type: List[int]
 
     def __copy__(self):

--- a/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
+++ b/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
@@ -94,7 +94,7 @@ class BoundedLoopsStrategy(BasicSearchStrategy):
                 return state
 
             elif annotation._reached_count[key] > self.bound:
-                log.info("Loop bound reached, skipping state")
+                log.debug("Loop bound reached, skipping state")
                 continue
 
             return state

--- a/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
+++ b/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
@@ -77,8 +77,8 @@ class BoundedLoopsStrategy(BasicSearchStrategy):
 
             key = cur_instr["address"]
 
-            for i in range(2, min(32, len(annotation.trace))):
-                key |= annotation.trace[-i] << (16 * i)
+            for i in range(1, min(128, len(annotation.trace))):
+                key |= annotation.trace[-i] << (i * 8)
 
             if key in annotation._reached_count:
                 annotation._reached_count[key] += 1

--- a/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
+++ b/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
@@ -75,10 +75,10 @@ class BoundedLoopsStrategy(BasicSearchStrategy):
 
             # create unique instruction identifier
 
-            key = 0
+            key = cur_instr["address"]
 
-            for i in range(1, min(32, len(annotation.trace))):
-                key |= annotation.trace[-i] << (8 * i)
+            for i in range(2, min(32, len(annotation.trace))):
+                key |= annotation.trace[-i] << (16 * i)
 
             if key in annotation._reached_count:
                 annotation._reached_count[key] += 1

--- a/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
+++ b/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
@@ -68,7 +68,7 @@ class BoundedLoopsStrategy(BasicSearchStrategy):
 
             cur_instr = state.get_current_instruction()
 
-            annotation.trace.append(cur_instr['address'])
+            annotation.trace.append(cur_instr["address"])
 
             if cur_instr["opcode"].upper() != "JUMPDEST":
                 return state
@@ -78,7 +78,7 @@ class BoundedLoopsStrategy(BasicSearchStrategy):
             key = 0
 
             for i in range(1, min(32, len(annotation.trace))):
-                key |= (annotation.trace[-i] << (8 * i))
+                key |= annotation.trace[-i] << (8 * i)
 
             if key in annotation._reached_count:
                 annotation._reached_count[key] += 1

--- a/tests/instructions/create2_test.py
+++ b/tests/instructions/create2_test.py
@@ -24,7 +24,7 @@ def generate_salted_address(code_str, salt, caller):
     salt = "0" * (64 - len(salt)) + salt
 
     contract_address = int(
-        get_code_hash("0xff" + addr + salt + get_code_hash(code_str)[2:])[26:], 16,
+        get_code_hash("0xff" + addr + salt + get_code_hash(code_str)[2:])[26:], 16
     )
     return contract_address
 


### PR DESCRIPTION
Replaces the loop counter key in the bounded loops module by a checksum over the last 32 pc addresses. This is to prevent unwanted pruning when an internal function is called repeatedly.