### PR TITLE
Modules selection usability overhaul

### DIFF
--- a/mythril/analysis/module/base.py
+++ b/mythril/analysis/module/base.py
@@ -42,7 +42,7 @@ class DetectionModule(ABC):
     - post_hooks: A list of instructions to hook the laser vm for (post execution of the instruction)
     """
 
-    name = "Detection Module Name"
+    name = "Detection Module Name / Title"
     swc_id = "SWC-000"
     description = "Detection module description"
     entry_point = EntryPoint.CALLBACK  # type: EntryPoint

--- a/mythril/analysis/module/loader.py
+++ b/mythril/analysis/module/loader.py
@@ -9,16 +9,20 @@ from mythril.analysis.module.modules.dependence_on_predictable_vars import (
 )
 from mythril.analysis.module.modules.deprecated_ops import DeprecatedOperations
 from mythril.analysis.module.modules.ether_thief import EtherThief
-from mythril.analysis.module.modules.exceptions import ReachableExceptions
+from mythril.analysis.module.modules.exceptions import Exceptions
 from mythril.analysis.module.modules.external_calls import ExternalCalls
 from mythril.analysis.module.modules.integer import IntegerArithmetics
 from mythril.analysis.module.modules.multiple_sends import MultipleSends
-from mythril.analysis.module.modules.state_change_external_calls import StateChangeAfterCall
+from mythril.analysis.module.modules.state_change_external_calls import (
+    StateChangeAfterCall,
+)
 from mythril.analysis.module.modules.suicide import AccidentallyKillable
 from mythril.analysis.module.modules.unchecked_retval import UncheckedRetval
 from mythril.analysis.module.modules.user_assertions import UserAssertions
 
 from mythril.analysis.module.base import EntryPoint
+
+from mythril.exceptions import DetectorNotFoundError
 
 from typing import Optional, List
 
@@ -53,11 +57,28 @@ class ModuleLoader(object, metaclass=Singleton):
         :param white_list: If specified: only return whitelisted detection modules
         :return: The selected detection modules
         """
+
         result = self._modules[:]
+
+        if white_list:
+
+            # Sanity check
+
+            available_names = [type(module).__name__ for module in result]
+
+            for name in white_list:
+                if name not in available_names:
+                    raise DetectorNotFoundError(
+                        "Invalid detection module: {}".format(name)
+                    )
+
+            result = [
+                module for module in result if type(module).__name__ in white_list
+            ]
+
         if entry_point:
             result = [module for module in result if module.entry_point == entry_point]
-        if white_list:
-            result = [module for module in result if module.name in white_list]
+
         return result
 
     def _register_mythril_modules(self):
@@ -69,7 +90,7 @@ class ModuleLoader(object, metaclass=Singleton):
                 PredictableVariables(),
                 DeprecatedOperations(),
                 EtherThief(),
-                ReachableExceptions(),
+                Exceptions(),
                 ExternalCalls(),
                 IntegerArithmetics(),
                 MultipleSends(),

--- a/mythril/analysis/module/loader.py
+++ b/mythril/analysis/module/loader.py
@@ -3,19 +3,19 @@ from mythril.support.support_utils import Singleton
 
 from mythril.analysis.module.modules.arbitrary_jump import ArbitraryJump
 from mythril.analysis.module.modules.arbitrary_write import ArbitraryStorage
-from mythril.analysis.module.modules.delegatecall import DelegateCallModule
+from mythril.analysis.module.modules.delegatecall import ArbitraryDelegateCall
 from mythril.analysis.module.modules.dependence_on_predictable_vars import (
-    PredictableDependenceModule,
+    PredictableVariables,
 )
-from mythril.analysis.module.modules.deprecated_ops import DeprecatedOperationsModule
+from mythril.analysis.module.modules.deprecated_ops import DeprecatedOperations
 from mythril.analysis.module.modules.ether_thief import EtherThief
-from mythril.analysis.module.modules.exceptions import ReachableExceptionsModule
+from mythril.analysis.module.modules.exceptions import ReachableExceptions
 from mythril.analysis.module.modules.external_calls import ExternalCalls
-from mythril.analysis.module.modules.integer import IntegerOverflowUnderflowModule
-from mythril.analysis.module.modules.multiple_sends import MultipleSendsModule
-from mythril.analysis.module.modules.state_change_external_calls import StateChange
-from mythril.analysis.module.modules.suicide import SuicideModule
-from mythril.analysis.module.modules.unchecked_retval import UncheckedRetvalModule
+from mythril.analysis.module.modules.integer import IntegerArithmetics
+from mythril.analysis.module.modules.multiple_sends import MultipleSends
+from mythril.analysis.module.modules.state_change_external_calls import StateChangeAfterCall
+from mythril.analysis.module.modules.suicide import AccidentallyKillable
+from mythril.analysis.module.modules.unchecked_retval import UncheckedRetval
 from mythril.analysis.module.modules.user_assertions import UserAssertions
 
 from mythril.analysis.module.base import EntryPoint
@@ -65,17 +65,17 @@ class ModuleLoader(object, metaclass=Singleton):
             [
                 ArbitraryJump(),
                 ArbitraryStorage(),
-                DelegateCallModule(),
-                PredictableDependenceModule(),
-                DeprecatedOperationsModule(),
+                ArbitraryDelegateCall(),
+                PredictableVariables(),
+                DeprecatedOperations(),
                 EtherThief(),
-                ReachableExceptionsModule(),
+                ReachableExceptions(),
                 ExternalCalls(),
-                IntegerOverflowUnderflowModule(),
-                MultipleSendsModule(),
-                StateChange(),
-                SuicideModule(),
-                UncheckedRetvalModule(),
+                IntegerArithmetics(),
+                MultipleSends(),
+                StateChangeAfterCall(),
+                AccidentallyKillable(),
+                UncheckedRetval(),
                 UserAssertions(),
             ]
         )

--- a/mythril/analysis/module/modules/arbitrary_jump.py
+++ b/mythril/analysis/module/modules/arbitrary_jump.py
@@ -9,14 +9,14 @@ log = logging.getLogger(__name__)
 
 DESCRIPTION = """
 
-Search for any writes to an arbitrary storage slot
+Search for jumps to arbitrary locations in the bytecode
 """
 
 
 class ArbitraryJump(DetectionModule):
     """This module searches for JUMPs to an arbitrary instruction."""
 
-    name = "Jump to an arbitrary line"
+    name = "Jump to an arbitrary bytecode location"
     swc_id = ARBITRARY_JUMP
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/arbitrary_write.py
+++ b/mythril/analysis/module/modules/arbitrary_write.py
@@ -21,7 +21,7 @@ Search for any writes to an arbitrary storage slot
 class ArbitraryStorage(DetectionModule):
     """This module searches for a feasible write to an arbitrary storage slot."""
 
-    name = "Arbitrary Storage Write"
+    name = "Write to an arbitrary storage location"
     swc_id = WRITE_TO_ARBITRARY_STORAGE
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/delegatecall.py
+++ b/mythril/analysis/module/modules/delegatecall.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 class ArbitraryDelegateCall(DetectionModule):
     """This module detects calldata being forwarded using DELEGATECALL."""
 
-    name = "DELEGATECALL Usage in Fallback Function"
+    name = "Delegatecall to a user-specified address"
     swc_id = DELEGATECALL_TO_UNTRUSTED_CONTRACT
     description = (
         "Check for invocations of delegatecall(msg.data) in the fallback function."

--- a/mythril/analysis/module/modules/delegatecall.py
+++ b/mythril/analysis/module/modules/delegatecall.py
@@ -19,7 +19,7 @@ from mythril.laser.smt import symbol_factory, UGT
 log = logging.getLogger(__name__)
 
 
-class DelegateCallModule(DetectionModule):
+class ArbitraryDelegateCall(DetectionModule):
     """This module detects calldata being forwarded using DELEGATECALL."""
 
     name = "DELEGATECALL Usage in Fallback Function"
@@ -100,4 +100,4 @@ class DelegateCallModule(DetectionModule):
             return []
 
 
-detector = DelegateCallModule()
+detector = ArbitraryDelegateCall()

--- a/mythril/analysis/module/modules/dependence_on_predictable_vars.py
+++ b/mythril/analysis/module/modules/dependence_on_predictable_vars.py
@@ -50,7 +50,7 @@ class OldBlockNumberUsedAnnotation(StateAnnotation):
         pass
 
 
-class PredictableDependenceModule(DetectionModule):
+class PredictableVariables(DetectionModule):
     """This module detects whether control flow decisions are made using predictable
     parameters."""
 
@@ -232,4 +232,4 @@ class PredictableDependenceModule(DetectionModule):
         return issues
 
 
-detector = PredictableDependenceModule()
+detector = PredictableVariables()

--- a/mythril/analysis/module/modules/dependence_on_predictable_vars.py
+++ b/mythril/analysis/module/modules/dependence_on_predictable_vars.py
@@ -54,7 +54,7 @@ class PredictableVariables(DetectionModule):
     """This module detects whether control flow decisions are made using predictable
     parameters."""
 
-    name = "Dependence of Predictable Variables"
+    name = "Control flow depends on a predictable environment variable"
     swc_id = "{} {}".format(TIMESTAMP_DEPENDENCE, WEAK_RANDOMNESS)
     description = (
         "Check whether important control flow decisions are influenced by block.coinbase,"

--- a/mythril/analysis/module/modules/deprecated_ops.py
+++ b/mythril/analysis/module/modules/deprecated_ops.py
@@ -15,7 +15,7 @@ Check for usage of deprecated opcodes
 """
 
 
-class DeprecatedOperationsModule(DetectionModule):
+class DeprecatedOperations(DetectionModule):
     """This module checks for the usage of deprecated op codes."""
 
     name = "Deprecated Operations"
@@ -87,4 +87,4 @@ class DeprecatedOperationsModule(DetectionModule):
         return [potential_issue]
 
 
-detector = DeprecatedOperationsModule()
+detector = DeprecatedOperations()

--- a/mythril/analysis/module/modules/deprecated_ops.py
+++ b/mythril/analysis/module/modules/deprecated_ops.py
@@ -18,7 +18,7 @@ Check for usage of deprecated opcodes
 class DeprecatedOperations(DetectionModule):
     """This module checks for the usage of deprecated op codes."""
 
-    name = "Deprecated Operations"
+    name = "Usage of deprecated instructions"
     swc_id = DEPRECATED_FUNCTIONS_USAGE
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/ether_thief.py
+++ b/mythril/analysis/module/modules/ether_thief.py
@@ -35,7 +35,7 @@ class EtherThief(DetectionModule):
     """This module search for cases where Ether can be withdrawn to a user-
     specified address."""
 
-    name = "Ether Thief"
+    name = "Attacker can profitably withdraw Ether from the contract account"
     swc_id = UNPROTECTED_ETHER_WITHDRAWAL
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/exceptions.py
+++ b/mythril/analysis/module/modules/exceptions.py
@@ -11,7 +11,7 @@ from mythril.laser.ethereum.state.global_state import GlobalState
 log = logging.getLogger(__name__)
 
 
-class ReachableExceptionsModule(DetectionModule):
+class ReachableExceptions(DetectionModule):
     """"""
 
     name = "Reachable Exceptions"
@@ -76,4 +76,4 @@ class ReachableExceptionsModule(DetectionModule):
         return []
 
 
-detector = ReachableExceptionsModule()
+detector = ReachableExceptions()

--- a/mythril/analysis/module/modules/exceptions.py
+++ b/mythril/analysis/module/modules/exceptions.py
@@ -11,7 +11,7 @@ from mythril.laser.ethereum.state.global_state import GlobalState
 log = logging.getLogger(__name__)
 
 
-class ReachableExceptions(DetectionModule):
+class Exceptions(DetectionModule):
     """"""
 
     name = "Reachable Exceptions"
@@ -76,4 +76,4 @@ class ReachableExceptions(DetectionModule):
         return []
 
 
-detector = ReachableExceptions()
+detector = Exceptions()

--- a/mythril/analysis/module/modules/exceptions.py
+++ b/mythril/analysis/module/modules/exceptions.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 class Exceptions(DetectionModule):
     """"""
 
-    name = "Reachable Exceptions"
+    name = "Exception or assertion violation"
     swc_id = ASSERT_VIOLATION
     description = "Checks whether any exception states are reachable."
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/external_calls.py
+++ b/mythril/analysis/module/modules/external_calls.py
@@ -49,7 +49,7 @@ class ExternalCalls(DetectionModule):
     """This module searches for low level calls (e.g. call.value()) that
     forward all gas to the callee."""
 
-    name = "External calls"
+    name = "External call to another contract"
     swc_id = REENTRANCY
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/integer.py
+++ b/mythril/analysis/module/modules/integer.py
@@ -61,7 +61,7 @@ class OverUnderflowStateAnnotation(StateAnnotation):
         return new_annotation
 
 
-class IntegerOverflowUnderflowModule(DetectionModule):
+class IntegerArithmetics(DetectionModule):
     """This module searches for integer over- and underflows."""
 
     name = "Integer Overflow and Underflow"
@@ -337,7 +337,7 @@ class IntegerOverflowUnderflowModule(DetectionModule):
             self.issues.append(issue)
 
 
-detector = IntegerOverflowUnderflowModule()
+detector = IntegerArithmetics()
 
 
 def _get_address_from_state(state):

--- a/mythril/analysis/module/modules/integer.py
+++ b/mythril/analysis/module/modules/integer.py
@@ -64,7 +64,7 @@ class OverUnderflowStateAnnotation(StateAnnotation):
 class IntegerArithmetics(DetectionModule):
     """This module searches for integer over- and underflows."""
 
-    name = "Integer Overflow and Underflow"
+    name = "Integer overflow or underflow"
     swc_id = INTEGER_OVERFLOW_AND_UNDERFLOW
     description = (
         "For every SUB instruction, check if there's a possible state "

--- a/mythril/analysis/module/modules/multiple_sends.py
+++ b/mythril/analysis/module/modules/multiple_sends.py
@@ -27,7 +27,7 @@ class MultipleSendsAnnotation(StateAnnotation):
 class MultipleSends(DetectionModule):
     """This module checks for multiple sends in a single transaction."""
 
-    name = "Multiple Sends"
+    name = "Multiple external calls in the same transaction"
     swc_id = MULTIPLE_SENDS
     description = "Check for multiple sends in a single transaction"
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/multiple_sends.py
+++ b/mythril/analysis/module/modules/multiple_sends.py
@@ -24,7 +24,7 @@ class MultipleSendsAnnotation(StateAnnotation):
         return result
 
 
-class MultipleSendsModule(DetectionModule):
+class MultipleSends(DetectionModule):
     """This module checks for multiple sends in a single transaction."""
 
     name = "Multiple Sends"
@@ -98,4 +98,4 @@ class MultipleSendsModule(DetectionModule):
         return []
 
 
-detector = MultipleSendsModule()
+detector = MultipleSends()

--- a/mythril/analysis/module/modules/state_change_external_calls.py
+++ b/mythril/analysis/module/modules/state_change_external_calls.py
@@ -99,7 +99,7 @@ class StateChangeAfterCall(DetectionModule):
     """This module searches for state change after low level calls (e.g. call.value()) that
     forward gas to the callee."""
 
-    name = "State Change After External calls"
+    name = "State change after external call"
     swc_id = REENTRANCY
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/state_change_external_calls.py
+++ b/mythril/analysis/module/modules/state_change_external_calls.py
@@ -99,7 +99,7 @@ class StateChangeAfterCall(DetectionModule):
     """This module searches for state change after low level calls (e.g. call.value()) that
     forward gas to the callee."""
 
-    name = "State change after external call"
+    name = "State change after an external call"
     swc_id = REENTRANCY
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/state_change_external_calls.py
+++ b/mythril/analysis/module/modules/state_change_external_calls.py
@@ -95,7 +95,7 @@ class StateChangeCallsAnnotation(StateAnnotation):
         )
 
 
-class StateChange(DetectionModule):
+class StateChangeAfterCall(DetectionModule):
     """This module searches for state change after low level calls (e.g. call.value()) that
     forward gas to the callee."""
 
@@ -159,13 +159,13 @@ class StateChange(DetectionModule):
         # Record state changes following from a transfer of ether
         if op_code in CALL_LIST:
             value = global_state.mstate.stack[-3]  # type: BitVec
-            if StateChange._balance_change(value, global_state):
+            if StateChangeAfterCall._balance_change(value, global_state):
                 for annotation in annotations:
                     annotation.state_change_states.append(global_state)
 
         # Record external calls
         if op_code in CALL_LIST:
-            StateChange._add_external_call(global_state)
+            StateChangeAfterCall._add_external_call(global_state)
 
         # Check for vulnerabilities
         vulnerabilities = []
@@ -195,4 +195,4 @@ class StateChange(DetectionModule):
                 return False
 
 
-detector = StateChange()
+detector = StateChangeAfterCall()

--- a/mythril/analysis/module/modules/suicide.py
+++ b/mythril/analysis/module/modules/suicide.py
@@ -23,7 +23,7 @@ class AccidentallyKillable(DetectionModule):
     """This module checks if the contact can be 'accidentally' killed by
     anyone."""
 
-    name = "Unprotected Selfdestruct"
+    name = "Contract can be accidentally killed by anyone"
     swc_id = UNPROTECTED_SELFDESTRUCT
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/analysis/module/modules/suicide.py
+++ b/mythril/analysis/module/modules/suicide.py
@@ -19,7 +19,7 @@ For kill-able contracts, also check whether it is possible to direct the contrac
 """
 
 
-class SuicideModule(DetectionModule):
+class AccidentallyKillable(DetectionModule):
     """This module checks if the contact can be 'accidentally' killed by
     anyone."""
 
@@ -106,4 +106,4 @@ class SuicideModule(DetectionModule):
         return []
 
 
-detector = SuicideModule()
+detector = AccidentallyKillable()

--- a/mythril/analysis/module/modules/unchecked_retval.py
+++ b/mythril/analysis/module/modules/unchecked_retval.py
@@ -31,7 +31,7 @@ class UncheckedRetvalAnnotation(StateAnnotation):
 class UncheckedRetval(DetectionModule):
     """A detection module to test whether CALL return value is checked."""
 
-    name = "Unchecked Return Value"
+    name = "Return value of an external call is not checked"
     swc_id = UNCHECKED_RET_VAL
     description = (
         "Test whether CALL return value is checked. "

--- a/mythril/analysis/module/modules/unchecked_retval.py
+++ b/mythril/analysis/module/modules/unchecked_retval.py
@@ -28,7 +28,7 @@ class UncheckedRetvalAnnotation(StateAnnotation):
         return result
 
 
-class UncheckedRetvalModule(DetectionModule):
+class UncheckedRetval(DetectionModule):
     """A detection module to test whether CALL return value is checked."""
 
     name = "Unchecked Return Value"
@@ -121,4 +121,4 @@ class UncheckedRetvalModule(DetectionModule):
         return []
 
 
-detector = UncheckedRetvalModule()
+detector = UncheckedRetval()

--- a/mythril/analysis/module/modules/user_assertions.py
+++ b/mythril/analysis/module/modules/user_assertions.py
@@ -28,7 +28,7 @@ assertion_failed_hash = (
 class UserAssertions(DetectionModule):
     """This module searches for user supplied exceptions: emit AssertionFailed("Error")."""
 
-    name = "User assertions"
+    name = "A user-defined assertion has been triggered"
     swc_id = ASSERT_VIOLATION
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK

--- a/mythril/exceptions.py
+++ b/mythril/exceptions.py
@@ -39,3 +39,10 @@ class AddressNotFoundError(MythrilBaseException):
     found."""
 
     pass
+
+
+class DetectorNotFoundError(MythrilBaseException):
+    """A Mythril exception denoting attempted usage of a non-existant
+    detection module."""
+
+    pass

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -794,8 +794,8 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
         if args.outform == "json":
             print(json.dumps(modules))
         else:
-            for module in modules:
-                print("{}: {}".format(module["classname"], module["title"]))
+            for module_data in modules:
+                print("{}: {}".format(module_data["classname"], module_data["title"]))
         sys.exit()
 
     if args.command == "help":

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -790,12 +790,12 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
     if args.command == "list-detectors":
         modules = []
         for module in ModuleLoader().get_detection_modules():
-            modules.append({'classname': type(module).__name__, 'title':  module.name})
+            modules.append({"classname": type(module).__name__, "title": module.name})
         if args.outform == "json":
             print(json.dumps(modules))
         else:
             for module in modules:
-                print("{}: {}".format(module['classname'], module['title']))
+                print("{}: {}".format(module["classname"], module["title"]))
         sys.exit()
 
     if args.command == "help":

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -233,6 +233,11 @@ def main() -> None:
     )
     create_pro_parser(pro_parser)
 
+    subparsers.add_parser(
+        "list-detectors",
+        parents=[output_parser],
+        help="Lists available detection modules",
+    )
     read_storage_parser = subparsers.add_parser(
         "read-storage",
         help="Retrieves storage slots from a given address through rpc",
@@ -250,11 +255,6 @@ def main() -> None:
     )
     subparsers.add_parser(
         "version", parents=[output_parser], help="Outputs the version"
-    )
-    subparsers.add_parser(
-        "list-detectors",
-        parents=[output_parser],
-        help="Lists available detection modules",
     )
     create_read_storage_parser(read_storage_parser)
     create_hash_to_addr_parser(contract_hash_to_addr)
@@ -769,6 +769,7 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
     :param parser: The parser
     :param args: The args
     """
+
 
     if args.epic:
         path = os.path.dirname(os.path.realpath(__file__))

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -788,12 +788,14 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
         sys.exit()
 
     if args.command == "list-detectors":
+        modules = []
         for module in ModuleLoader().get_detection_modules():
-            print("{}: {}".format(type(module).__name__, module.name))
+            modules.append({'classname': type(module).__name__, 'title':  module.name})
         if args.outform == "json":
-            print(json.dumps({"version_str": VERSION}))
+            print(json.dumps(modules))
         else:
-            print("Mythril version {}".format(VERSION))
+            for module in modules:
+                print("{}: {}".format(module['classname'], module['title']))
         sys.exit()
 
     if args.command == "help":

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -17,7 +17,11 @@ import traceback
 import mythril.support.signatures as sigs
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from mythril import mythx
-from mythril.exceptions import AddressNotFoundError, CriticalError
+from mythril.exceptions import (
+    AddressNotFoundError,
+    DetectorNotFoundError,
+    CriticalError,
+)
 from mythril.laser.ethereum.transaction.symbolic import ACTORS
 from mythril.mythril import (
     MythrilAnalyzer,
@@ -729,9 +733,11 @@ def execute_command(
                     "markdown": report.as_markdown(),
                 }
                 print(outputs[args.outform])
-            except ModuleNotFoundError as e:
+            except DetectorNotFoundError as e:
+                exit_with_error(args.outform, format(e))
+            except CriticalError as e:
                 exit_with_error(
-                    args.outform, "Error loading analysis modules: " + format(e)
+                    args.outform, "Analysis error encountered: " + format(e)
                 )
 
     else:

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -770,7 +770,6 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
     :param args: The args
     """
 
-
     if args.epic:
         path = os.path.dirname(os.path.realpath(__file__))
         sys.argv.remove("--epic")

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -29,6 +29,9 @@ from mythril.mythril import (
     MythrilConfig,
     MythrilLevelDB,
 )
+
+from mythril.analysis.module import ModuleLoader
+
 from mythril.__version__ import __version__ as VERSION
 
 ANALYZE_LIST = ("analyze", "a")
@@ -46,6 +49,7 @@ COMMAND_LIST = (
         "leveldb-search",
         "function-to-hash",
         "hash-to-address",
+        "list-detectors",
         "version",
         "truffle",
         "help",
@@ -246,6 +250,11 @@ def main() -> None:
     )
     subparsers.add_parser(
         "version", parents=[output_parser], help="Outputs the version"
+    )
+    subparsers.add_parser(
+        "list-detectors",
+        parents=[output_parser],
+        help="Lists available detection modules",
     )
     create_read_storage_parser(read_storage_parser)
     create_hash_to_addr_parser(contract_hash_to_addr)
@@ -772,6 +781,15 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
         sys.exit()
 
     if args.command == "version":
+        if args.outform == "json":
+            print(json.dumps({"version_str": VERSION}))
+        else:
+            print("Mythril version {}".format(VERSION))
+        sys.exit()
+
+    if args.command == "list-detectors":
+        for module in ModuleLoader().get_detection_modules():
+            print("{}: {}".format(type(module).__name__, module.name))
         if args.outform == "json":
             print(json.dumps({"version_str": VERSION}))
         else:

--- a/mythril/laser/ethereum/keccak_function_manager.py
+++ b/mythril/laser/ethereum/keccak_function_manager.py
@@ -141,7 +141,7 @@ class KeccakFunctionManager:
         )
         concrete_cond = symbol_factory.Bool(False)
         for key, keccak in self.concrete_hashes.items():
-            hash_eq = And(func(func_input) == keccak, key == func_input,)
+            hash_eq = And(func(func_input) == keccak, key == func_input)
             concrete_cond = Or(concrete_cond, hash_eq)
         return And(inv(func(func_input)) == func_input, Or(cond, concrete_cond))
 

--- a/mythril/mythril/mythril_analyzer.py
+++ b/mythril/mythril/mythril_analyzer.py
@@ -18,6 +18,7 @@ from mythril.analysis.report import Report, Issue
 from mythril.ethereum.evmcontract import EVMContract
 from mythril.laser.smt import SolverStatistics
 from mythril.support.start_time import StartTime
+from mythril.exceptions import DetectorNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -172,6 +173,9 @@ class MythrilAnalyzer:
                     custom_modules_directory=self.custom_modules_directory,
                 )
                 issues = fire_lasers(sym, modules)
+            except DetectorNotFoundError as e:
+                # Bubble up
+                raise e
             except KeyboardInterrupt:
                 log.critical("Keyboard Interrupt")
                 if self.iprof is not None:


### PR DESCRIPTION
I refactored the class names and "name" fields of each module for consistency and added the following:

1. Users can now select modules by classname:

```
$ myth analyze test.sol -mIntegerArithmetics,Exceptions
```

2. Adding a non-existent module throws an error:

```
$ myth analyze test.sol -mIntegerArithmetics,Exceptions,Lol
mythril.interfaces.cli [ERROR]: Invalid detection module: Lol 
```

3. The new command "list-detectors" provides a list of the available modules:

```
$ myth list-detectors
ArbitraryJump: Jump to an arbitrary bytecode location
ArbitraryStorage: Write to an arbitrary storage location
ArbitraryDelegateCall: Delegatecall to a user-specified address
PredictableVariables: Control flow depends on a predictable environment variable
DeprecatedOperations: Usage of deprecated instructions
EtherThief: Attacker can profitably withdraw Ether from the contract account
Exceptions: Exception or assertion violation
ExternalCalls: External call to another contract
IntegerArithmetics: Integer overflow or underflow
MultipleSends: Multiple external calls in the same transaction
StateChangeAfterCall: State change after external call
AccidentallyKillable: Contract can be accidentally killed by anyone
UncheckedRetval: Return value of an external call is not checked
UserAssertions: A user-defined assertion has been triggered
```