### PR TITLE
Load intial account balances from blockchain and refactor loader flags

### DIFF
--- a/mythril/analysis/symbolic.py
+++ b/mythril/analysis/symbolic.py
@@ -176,6 +176,7 @@ class SymExecWrapper:
                 contract.disassembly,
                 dynamic_loader=dynloader,
                 contract_name=contract.name,
+                balances=world_state.balances,
                 concrete_storage=True
                 if (dynloader is not None and dynloader.storage_loading)
                 else False,

--- a/mythril/analysis/symbolic.py
+++ b/mythril/analysis/symbolic.py
@@ -96,10 +96,10 @@ class SymExecWrapper:
             raise ValueError("Invalid strategy argument supplied")
 
         creator_account = Account(
-            hex(ACTORS.creator.value), "", dynamic_loader=dynloader, contract_name=None
+            hex(ACTORS.creator.value), "", dynamic_loader=None, contract_name=None
         )
         attacker_account = Account(
-            hex(ACTORS.attacker.value), "", dynamic_loader=dynloader, contract_name=None
+            hex(ACTORS.attacker.value), "", dynamic_loader=None, contract_name=None
         )
 
         requires_statespace = (

--- a/mythril/ethereum/interface/rpc/client.py
+++ b/mythril/ethereum/interface/rpc/client.py
@@ -52,12 +52,7 @@ class EthJsonRpc(BaseClient):
         :return:
         """
         params = params or []
-        data = {
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-            "id": _id,
-        }
+        data = {"jsonrpc": "2.0", "method": method, "params": params, "id": _id}
         scheme = "http"
         if self.tls:
             scheme += "s"

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -387,9 +387,7 @@ def create_analyzer_parser(analyzer_parser: ArgumentParser):
         action="store_true",
         help="analyze a truffle project (run from project dir)",
     )
-    commands.add_argument(
-        "--infura-id", help="set infura id for onchain analysis",
-    )
+    commands.add_argument("--infura-id", help="set infura id for onchain analysis")
 
     options = analyzer_parser.add_argument_group("options")
     options.add_argument(

--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -128,8 +128,12 @@ class Account:
         self.balance = lambda: self._balances[self.address]
 
         if not self.address.symbolic and dynamic_loader is not None:
-            _balance = dynamic_loader.read_balance(formatted_address)
-            self.set_balance(_balance)
+            try:
+                _balance = dynamic_loader.read_balance(formatted_address)
+                self.set_balance(_balance)
+            except:
+                # Initial balance will be a symbolic variable
+                pass
 
     def __str__(self) -> str:
         return str(self.as_dict)

--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -112,14 +112,12 @@ class Account:
             concrete_storage, address=self.address, dynamic_loader=dynamic_loader
         )
 
-        formatted_address = "{0:#0{1}x}".format(self.address.value, 42);
+        formatted_address = "{0:#0{1}x}".format(self.address.value, 42)
 
         # Metadata
         if contract_name is None:
             self.contract_name = (
-                formatted_address
-                if not self.address.symbolic
-                else "unknown"
+                formatted_address if not self.address.symbolic else "unknown"
             )
         else:
             self.contract_name = contract_name
@@ -131,9 +129,7 @@ class Account:
 
         if not self.address.symbolic and dynamic_loader is not None:
             _balance = dynamic_loader.read_balance(formatted_address)
-            self.set_balance(
-                _balance
-            )
+            self.set_balance(_balance)
 
     def __str__(self) -> str:
         return str(self.as_dict)

--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -112,10 +112,12 @@ class Account:
             concrete_storage, address=self.address, dynamic_loader=dynamic_loader
         )
 
+        formatted_address = "{0:#0{1}x}".format(self.address.value, 42);
+
         # Metadata
         if contract_name is None:
             self.contract_name = (
-                "{0:#0{1}x}".format(self.address.value, 40)
+                formatted_address
                 if not self.address.symbolic
                 else "unknown"
             )
@@ -126,6 +128,12 @@ class Account:
 
         self._balances = balances
         self.balance = lambda: self._balances[self.address]
+
+        if not self.address.symbolic and dynamic_loader is not None:
+            _balance = dynamic_loader.read_balance(formatted_address)
+            self.set_balance(
+                _balance
+            )
 
     def __str__(self) -> str:
         return str(self.as_dict)

--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -112,12 +112,12 @@ class Account:
             concrete_storage, address=self.address, dynamic_loader=dynamic_loader
         )
 
-        formatted_address = "{0:#0{1}x}".format(self.address.value, 42)
-
         # Metadata
         if contract_name is None:
             self.contract_name = (
-                formatted_address if not self.address.symbolic else "unknown"
+                "{0:#0{1}x}".format(self.address.value, 42)
+                if not self.address.symbolic
+                else "unknown"
             )
         else:
             self.contract_name = contract_name
@@ -129,7 +129,9 @@ class Account:
 
         if not self.address.symbolic and dynamic_loader is not None:
             try:
-                _balance = dynamic_loader.read_balance(formatted_address)
+                _balance = dynamic_loader.read_balance(
+                    "{0:#0{1}x}".format(self.address.value, 42)
+                )
                 self.set_balance(_balance)
             except:
                 # Initial balance will be a symbolic variable

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -49,9 +49,7 @@ class DynLoader:
         :return:
         """
         if not self.active:
-            raise ValueError(
-                "Cannot load from storage when the loader is disabled"
-            )
+            raise ValueError("Cannot load from storage when the loader is disabled")
         if not self.eth:
             raise ValueError("Cannot load from the chain when eth is None")
 

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -48,7 +48,7 @@ class DynLoader:
         :param address:
         :return:
         """
-        if not self.storage_loading:
+        if not self.active:
             raise ValueError(
                 "Cannot load from the storage when the storage_loading flag is false"
             )

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -53,7 +53,7 @@ class DynLoader:
                 "Cannot load from storage when the loader is disabled"
             )
         if not self.eth:
-            raise ValueError("Cannot load from the storage when eth is None")
+            raise ValueError("Cannot load from the chain when eth is None")
 
         return self.eth.eth_getBalance(address)
 

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -48,6 +48,22 @@ class DynLoader:
         )
 
     @functools.lru_cache(LRU_CACHE_SIZE)
+    def read_balance(self, address: str) -> str:
+        """
+
+        :param address:
+        :return:
+        """
+        if not self.storage_loading:
+            raise ValueError(
+                "Cannot load from the storage when the storage_loading flag is false"
+            )
+        if not self.eth:
+            raise ValueError("Cannot load from the storage when eth is None")
+
+        return self.eth.eth_getBalance(address)
+
+    @functools.lru_cache(LRU_CACHE_SIZE)
     def dynld(self, dependency_address: str) -> Optional[Disassembly]:
         """
         :param dependency_address:

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -50,7 +50,7 @@ class DynLoader:
         """
         if not self.active:
             raise ValueError(
-                "Cannot load from the storage when the storage_loading flag is false"
+                "Cannot load from storage when the loader is disabled"
             )
         if not self.eth:
             raise ValueError("Cannot load from the storage when eth is None")


### PR DESCRIPTION
- Adds new function `read_balance(address` to dynloader
- Account constructor now reads intial account balance from blockchain if dynloader is available
- Minor: Don't pass dynloader to `CREATOR_ACCOUNT` and `ATTACKER_ACCOUNT` which are virtual
- Use a single boolean / flag to determine if data should be loaded instead of separating code/storage/balances:

```
  --no-onchain-data. Don't attempt to retrieve contract code, variables and balances from the blockchain
```