### PR TITLE
Revert Ether thief change & introduce symbolic starting balance

### DIFF
--- a/mythril/analysis/module/modules/ether_thief.py
+++ b/mythril/analysis/module/modules/ether_thief.py
@@ -40,7 +40,7 @@ class EtherThief(DetectionModule):
     swc_id = UNPROTECTED_ETHER_WITHDRAWAL
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK
-    pre_hooks = ["STOP"]
+    pre_hooks = ["CALL", "STATICCALL"]
 
     def reset_module(self):
         """
@@ -70,16 +70,16 @@ class EtherThief(DetectionModule):
         """
         state = copy(state)
         instruction = state.get_current_instruction()
+        to = state.mstate.stack[-2]
 
         constraints = copy(state.world_state.constraints)
 
-        attacker_address_bitvec = ACTORS.attacker
-
         constraints += [
+            to == ACTORS.attacker,
             UGT(
-                state.world_state.balances[attacker_address_bitvec],
-                state.world_state.starting_balances[attacker_address_bitvec],
-            )
+                state.world_state.balances[ACTORS.attacker],
+                state.world_state.starting_balances[ACTORS.attacker],
+            ),
         ]
 
         potential_issue = PotentialIssue(

--- a/mythril/laser/ethereum/state/world_state.py
+++ b/mythril/laser/ethereum/state/world_state.py
@@ -125,7 +125,7 @@ class WorldState:
 
     def create_account(
         self,
-        balance=0,
+        balance=None,
         address=None,
         concrete_storage=False,
         dynamic_loader=None,
@@ -157,7 +157,12 @@ class WorldState:
         if code:
             new_account.code = code
 
-        new_account.set_balance(symbol_factory.BitVecVal(balance, 256))
+        if balance is not None:
+            new_account.set_balance(symbol_factory.BitVecVal(balance, 256))
+        else:
+            new_account.set_balance(
+                symbol_factory.BitVecSym("initial)_balance_{}".format(address), 256)
+            )
 
         self.put_account(new_account)
         return new_account

--- a/mythril/laser/ethereum/transaction/transaction_models.py
+++ b/mythril/laser/ethereum/transaction/transaction_models.py
@@ -202,7 +202,7 @@ class ContractCreationTransaction(BaseTransaction):
             contract_address if isinstance(contract_address, int) else None
         )
         callee_account = world_state.create_account(
-            0, concrete_storage=True, creator=caller.value, address=contract_address
+            concrete_storage=True, creator=caller.value, address=contract_address
         )
         callee_account.contract_name = contract_name or callee_account.contract_name
         # init_call_data "should" be false, but it is easier to model the calldata symbolically


### PR DESCRIPTION
- Reverts the Ether thief change of hooking the STOP instruction which lead to a huge slowdown
- [OPINIONATED] Make initial balance of newly created contract accounts a symbolic variable instead of 0 (see A20-582)

^^ Some reasons for change 2:

- In real environment, a newly created contract account could already have a balance
- Makes it easier to search for flash loan arbitrage opportunities by assuming that the contract has arbitrary amount of ETH available
- Less tx required to detect Ether theft (otherwise contract needs an initial tx to be topped up)
