### PR TITLE
Simplify EtherThief and fix pruning behaviour

### DIFF
--- a/mythril/analysis/module/modules/ether_thief.py
+++ b/mythril/analysis/module/modules/ether_thief.py
@@ -84,8 +84,7 @@ class EtherThief(DetectionModule):
             bytecode=state.environment.code.bytecode,
             description_head="Anyone can withdraw ETH from the contract account.",
             description_tail="Arbitrary senders other than the contract creator can withdraw ETH from the contract"
-            + " account without previously having sent an equivalent amount of ETH to it. This is likely to be"
-            + " a vulnerability.",
+            + " account. This is likely to be a vulnerability.",
             detector=self,
             constraints=constraints,
         )

--- a/mythril/analysis/module/modules/ether_thief.py
+++ b/mythril/analysis/module/modules/ether_thief.py
@@ -18,11 +18,8 @@ log = logging.getLogger(__name__)
 
 DESCRIPTION = """
 Search for cases where Ether can be withdrawn to a user-specified address.
-An issue is reported if:
-- The transaction sender does not match contract creator;
-- The sender address can be chosen arbitrarily;
-- The receiver address is identical to the sender address;
-- The sender can withdraw *more* than the total amount they sent over all transactions.
+An issue is reported if there is a valid end state where the attacker has successfully
+increased their Ether balance.
 """
 
 

--- a/mythril/analysis/module/modules/ether_thief.py
+++ b/mythril/analysis/module/modules/ether_thief.py
@@ -35,6 +35,7 @@ class EtherThief(DetectionModule):
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK
     pre_hooks = ["CALL", "STATICCALL"]
+    post_hooks = ["CALL", "STATICCALL"]
 
     def reset_module(self):
         """
@@ -62,16 +63,19 @@ class EtherThief(DetectionModule):
         """
         state = copy(state)
         instruction = state.get_current_instruction()
-        to = state.mstate.stack[-2]
 
         constraints = copy(state.world_state.constraints)
 
+        """
+        Fixme: Potential issue should only be created it call target is the attacker.
+        This requires a prehook in addition to the posthook
+        """
+
         constraints += [
-            to == ACTORS.attacker,
             UGT(
                 state.world_state.balances[ACTORS.attacker],
                 state.world_state.starting_balances[ACTORS.attacker],
-            ),
+            )
         ]
 
         potential_issue = PotentialIssue(

--- a/mythril/analysis/module/modules/ether_thief.py
+++ b/mythril/analysis/module/modules/ether_thief.py
@@ -34,7 +34,6 @@ class EtherThief(DetectionModule):
     swc_id = UNPROTECTED_ETHER_WITHDRAWAL
     description = DESCRIPTION
     entry_point = EntryPoint.CALLBACK
-    pre_hooks = ["CALL", "STATICCALL"]
     post_hooks = ["CALL", "STATICCALL"]
 
     def reset_module(self):
@@ -67,7 +66,7 @@ class EtherThief(DetectionModule):
         constraints = copy(state.world_state.constraints)
 
         """
-        Fixme: Potential issue should only be created it call target is the attacker.
+        FIXME: Potential issue should only be created it call target is the attacker.
         This requires a prehook in addition to the posthook
         """
 

--- a/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
+++ b/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
@@ -3,12 +3,14 @@ from mythril.laser.ethereum.plugins.plugin import LaserPlugin
 from mythril.laser.ethereum.plugins.implementations.plugin_annotations import (
     MutationAnnotation,
 )
+from mythril.laser.smt.bitvec_helper import UGT
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.svm import LaserEVM
 from mythril.laser.ethereum.transaction.transaction_models import (
     ContractCreationTransaction,
 )
-from mythril.laser.smt import And, symbol_factory
+from mythril.analysis import solver
+from mythril.exceptions import UnsatError, CriticalError
 
 
 class MutationPruner(LaserPlugin):
@@ -38,27 +40,23 @@ class MutationPruner(LaserPlugin):
         def sstore_mutator_hook(global_state: GlobalState):
             global_state.annotate(MutationAnnotation())
 
-        @symbolic_vm.pre_hook("CALL")
-        def call_mutator_hook(global_state: GlobalState):
-            global_state.annotate(MutationAnnotation())
-
-        @symbolic_vm.pre_hook("STATICCALL")
-        def staticcall_mutator_hook(global_state: GlobalState):
-            global_state.annotate(MutationAnnotation())
-
         @symbolic_vm.laser_hook("add_world_state")
         def world_state_filter_hook(global_state: GlobalState):
-            if And(
-                *global_state.world_state.constraints[:]
-                + [
-                    global_state.environment.callvalue
-                    > symbol_factory.BitVecVal(0, 256)
-                ]
-            ).is_false:
-                return
+
             if isinstance(
                 global_state.current_transaction, ContractCreationTransaction
             ):
                 return
+
+            try:
+                constraints = global_state.world_state.constraints + [
+                    global_state.environment.callvalue > 0
+                ]
+
+                solver.get_model(constraints)
+                return
+            except UnsatError:
+                pass
+
             if len(list(global_state.get_annotations(MutationAnnotation))) == 0:
                 raise PluginSkipWorldState

--- a/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
+++ b/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
@@ -67,6 +67,7 @@ class MutationPruner(LaserPlugin):
                 solver.get_model(constraints)
                 return
             except UnsatError:
+                # callvalue is constrained to 0, therefore there is no balance based world state mutation
                 pass
 
             if len(list(global_state.get_annotations(MutationAnnotation))) == 0:

--- a/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
+++ b/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
@@ -3,14 +3,13 @@ from mythril.laser.ethereum.plugins.plugin import LaserPlugin
 from mythril.laser.ethereum.plugins.implementations.plugin_annotations import (
     MutationAnnotation,
 )
-from mythril.laser.smt.bitvec_helper import UGT
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.svm import LaserEVM
 from mythril.laser.ethereum.transaction.transaction_models import (
     ContractCreationTransaction,
 )
 from mythril.analysis import solver
-from mythril.exceptions import UnsatError, CriticalError
+from mythril.exceptions import UnsatError
 
 
 class MutationPruner(LaserPlugin):

--- a/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
+++ b/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
@@ -40,6 +40,18 @@ class MutationPruner(LaserPlugin):
         def sstore_mutator_hook(global_state: GlobalState):
             global_state.annotate(MutationAnnotation())
 
+        """FIXME: Check for changes in world_state.balances instead of adding MutationAnnotation for all calls.
+           Requires world_state.starting_balances to be initalized at every tx start *after* call value has been added.
+        """
+
+        @symbolic_vm.pre_hook("CALL")
+        def call_mutator_hook(global_state: GlobalState):
+            global_state.annotate(MutationAnnotation())
+
+        @symbolic_vm.pre_hook("STATICCALL")
+        def staticcall_mutator_hook(global_state: GlobalState):
+            global_state.annotate(MutationAnnotation())
+
         @symbolic_vm.laser_hook("add_world_state")
         def world_state_filter_hook(global_state: GlobalState):
 

--- a/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
+++ b/mythril/laser/ethereum/plugins/implementations/mutation_pruner.py
@@ -5,6 +5,7 @@ from mythril.laser.ethereum.plugins.implementations.plugin_annotations import (
 )
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.svm import LaserEVM
+from mythril.laser.smt import UGT, symbol_factory
 from mythril.laser.ethereum.transaction.transaction_models import (
     ContractCreationTransaction,
 )
@@ -59,9 +60,17 @@ class MutationPruner(LaserPlugin):
             ):
                 return
 
+            if isinstance(global_state.environment.callvalue, int):
+                callvalue = symbol_factory.BitVecVal(
+                    global_state.environment.callvalue, 256
+                )
+            else:
+                callvalue = global_state.environment.callvalue
+
             try:
+
                 constraints = global_state.world_state.constraints + [
-                    global_state.environment.callvalue > 0
+                    UGT(callvalue, symbol_factory.BitVecVal(0, 256))
                 ]
 
                 solver.get_model(constraints)

--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -145,6 +145,7 @@ def execute_contract_creation(
         )
         _setup_global_state_for_execution(laser_evm, transaction)
         new_account = new_account or transaction.callee_account
+
     laser_evm.exec(True)
 
     return new_account


### PR DESCRIPTION
- Revert to hooking `CALL` and `STATICCALL` in EtherThief module
- Prevent`MutationPruner` from pruning paths that where ETH could have been received via msg.value

**TESTS**

**No payable functions:**

```
pragma solidity ^0.5.0;

contract SimpleEtherDrain {

  function withdrawAllAnyone() public {
    msg.sender.transfer(address(this).balance);
  }
}
```
```
$ $MYTH a SimpleEtherDrain.sol -mEtherThief
The analysis was completed successfully. No issues were detected.
```

**Payable constructor:**

```
pragma solidity ^0.5.0;

contract SimpleEtherDrain {

  constructor() public payable {
  }

  function withdrawAllAnyone() public {
    msg.sender.transfer(address(this).balance);
  }
}
```
```
$ $MYTH a SimpleEtherDrain.sol -mEtherThief -t1
==== Unprotected Ether Withdrawal ====
SWC ID: 105
Severity: High
Contract: SimpleEtherDrain
Function name: withdrawAllAnyone()
PC address: 102
Estimated Gas Usage: 924 - 35205
Anyone can withdraw ETH from the contract account.
Arbitrary senders other than the contract creator can withdraw ETH from the contract account. This is likely to be a vulnerability.
--------------------
In file: SimpleEtherDrain.sol:9

msg.sender.transfer(address(this).balance)

--------------------
Initial State:

Account: [CREATOR], balance: 0x8, nonce:0, storage:{}
Account: [ATTACKER], balance: 0x2000, nonce:0, storage:{}
Account: [SOMEGUY], balance: 0x0, nonce:0, storage:{}

Transaction Sequence:

Caller: [CREATOR], calldata: , value: 0x1
Caller: [ATTACKER], function: withdrawAllAnyone(), txdata: 0x6aba6fa1, value: 0x0
```

**No payable constructor + payable fallback function:**

```
pragma solidity ^0.5.0;

contract SimpleEtherDrain {

  constructor() public payable {
  }

  function withdrawAllAnyone() public {
    msg.sender.transfer(address(this).balance);
  }
}
```
```
$ $MYTH a SimpleEtherDrain.sol -mEtherThief -t1
The analysis was completed successfully. No issues were detected.
```
```
(mythril) Bernhards-MacBook-Pro:Desktop bernhardmueller$ $MYTH a SimpleEtherDrain.sol -mEtherThief -t2
==== Unprotected Ether Withdrawal ====
SWC ID: 105
Severity: High
Contract: SimpleEtherDrain
Function name: withdrawAllAnyone()
PC address: 99
Estimated Gas Usage: 924 - 35205
Anyone can withdraw ETH from the contract account.
Arbitrary senders other than the contract creator can withdraw ETH from the contract account. This is likely to be a vulnerability.
--------------------
In file: SimpleEtherDrain.sol:6

msg.sender.transfer(address(this).balance)

--------------------
Initial State:

Account: [CREATOR], balance: 0x0, nonce:0, storage:{}
Account: [ATTACKER], balance: 0x2150200048852400, nonce:0, storage:{}
Account: [SOMEGUY], balance: 0x0, nonce:0, storage:{}

Transaction Sequence:

Caller: [CREATOR], calldata: , value: 0x0
Caller: [SOMEGUY], function: unknown, txdata: 0x40000402, value: 0x1
Caller: [ATTACKER], function: withdrawAllAnyone(), txdata: 0x6aba6fa1, value: 0x0
```