### PR TITLE
Always report user assertions

### DIFF
--- a/mythril/analysis/module/modules/user_assertions.py
+++ b/mythril/analysis/module/modules/user_assertions.py
@@ -45,7 +45,6 @@ class UserAssertions(DetectionModule):
             self.cache.add(issue.address)
         self.issues.extend(issues)
 
-
     def _analyze_state(self, state: GlobalState):
         """
 

--- a/mythril/laser/ethereum/state/constraints.py
+++ b/mythril/laser/ethereum/state/constraints.py
@@ -13,7 +13,7 @@ class Constraints(list):
 
     """
 
-    def __init__(self, constraint_list: Optional[List[Bool]] = None,) -> None:
+    def __init__(self, constraint_list: Optional[List[Bool]] = None) -> None:
         """
 
         :param constraint_list: List of constraints


### PR DESCRIPTION
As a user I want violations of user assertions to always be reported even if the transaction reverts. This PR changes the UserAssertion module to add an issue instead of a `PotentialIssue` when a violation is encountered.

Also, black reformatted something in constraints.py :)