### PR TITLE
Update solcx version

### DIFF
--- a/mythril/ethereum/util.py
+++ b/mythril/ethereum/util.py
@@ -14,6 +14,7 @@ from mythril.exceptions import CompilerError
 
 if sys.version_info[1] >= 6:
     import solcx
+    from solcx.exceptions import SolcNotInstalled
 
 
 def safe_decode(hex_encoded_string):
@@ -131,12 +132,15 @@ def solc_exists(version):
                 "bin/solc",
             )  # py-solc setup
         ]
+        for solc_path in solc_binaries:
+            if os.path.exists(solc_path):
+                return solc_path
     elif sys.version_info[1] >= 6:
         # we are using solc-x for the the 0.5 and higher
-        solc_binaries = [os.path.join(solcx.__path__[0], "bin", "solc-v" + version)]
-    for solc_path in solc_binaries:
-        if os.path.exists(solc_path):
-            return solc_path
+        try:
+            return solcx.install.get_executable(version)
+        except SolcNotInstalled:
+            pass
 
     # Last resort is to use the system installation
     default_binary = "/usr/bin/solc"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ persistent>=4.2.0
 plyvel
 py-flags
 py-evm==0.3.0a13
-py-solc-x==0.6.0
+py-solc-x==0.10.0
 py-solc
 pytest>=3.6.0
 pytest-cov


### PR DESCRIPTION
While re-configuring my python dev environment I had some issues with the version of py-solc-x that we were using.
I've updated the version to the most recent `0.10.0` and fixed up some of the code that would interact with the solc x installed binaries.
This now uses the function `get_executable` rather than trying to find the compiler binary manually.