### PR TITLE
Change plugin_name to name

### DIFF
--- a/mythril/laser/plugin/builder.py
+++ b/mythril/laser/plugin/builder.py
@@ -10,7 +10,7 @@ class PluginBuilder(ABC):
     The plugin builder interface enables construction of Laser plugins
     """
 
-    plugin_name = "Default Plugin Name"
+    name = "Default Plugin Name"
 
     def __init__(self):
         self.enabled = True

--- a/mythril/laser/plugin/loader.py
+++ b/mythril/laser/plugin/loader.py
@@ -27,13 +27,13 @@ class LaserPluginLoader(object, metaclass=Singleton):
 
         :param plugin_builder: Builder that constructs the plugin
         """
-        log.info(f"Loading laser plugin: {plugin_builder.plugin_name}")
-        if plugin_builder.plugin_name in self.laser_plugin_builders:
+        log.info(f"Loading laser plugin: {plugin_builder.name}")
+        if plugin_builder.name in self.laser_plugin_builders:
             log.warning(
-                f"Laser plugin with name {plugin_builder.plugin_name} was already loaded, skipping..."
+                f"Laser plugin with name {plugin_builder.name} was already loaded, skipping..."
             )
             return
-        self.laser_plugin_builders[plugin_builder.plugin_name] = plugin_builder
+        self.laser_plugin_builders[plugin_builder.name] = plugin_builder
 
     def is_enabled(self, plugin_name: str) -> bool:
         """ Returns whether the plugin is loaded in the symbolic_vm

--- a/mythril/laser/plugin/plugins/benchmark.py
+++ b/mythril/laser/plugin/plugins/benchmark.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 class BenchmarkPluginBuilder(PluginBuilder):
-    plugin_name = "benchmark"
+    name = "benchmark"
 
     def __call__(self, *args, **kwargs):
         return BenchmarkPlugin()

--- a/mythril/laser/plugin/plugins/call_depth_limiter.py
+++ b/mythril/laser/plugin/plugins/call_depth_limiter.py
@@ -6,7 +6,7 @@ from mythril.laser.ethereum.svm import LaserEVM
 
 
 class CallDepthLimitBuilder(PluginBuilder):
-    plugin_name = "call-depth-limit"
+    name = "call-depth-limit"
 
     def __call__(self, *args, **kwargs):
         return CallDepthLimit(kwargs["call_depth_limit"])

--- a/mythril/laser/plugin/plugins/coverage/coverage_plugin.py
+++ b/mythril/laser/plugin/plugins/coverage/coverage_plugin.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 class CoveragePluginBuilder(PluginBuilder):
-    plugin_name = "coverage"
+    name = "coverage"
 
     def __call__(self, *args, **kwargs):
         return InstructionCoveragePlugin()

--- a/mythril/laser/plugin/plugins/dependency_pruner.py
+++ b/mythril/laser/plugin/plugins/dependency_pruner.py
@@ -71,7 +71,7 @@ def get_ws_dependency_annotation(state: GlobalState) -> WSDependencyAnnotation:
 
 
 class DependencyPrunerBuilder(PluginBuilder):
-    plugin_name = "dependency-pruner"
+    name = "dependency-pruner"
 
     def __call__(self, *args, **kwargs):
         return DependencyPruner()

--- a/mythril/laser/plugin/plugins/instruction_profiler.py
+++ b/mythril/laser/plugin/plugins/instruction_profiler.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 
 class InstructionProfilerBuilder(PluginBuilder):
-    plugin_name = "instruction-profiler"
+    name = "instruction-profiler"
 
     def __call__(self, *args, **kwargs):
         return InstructionProfiler()

--- a/mythril/laser/plugin/plugins/mutation_pruner.py
+++ b/mythril/laser/plugin/plugins/mutation_pruner.py
@@ -13,7 +13,7 @@ from mythril.exceptions import UnsatError
 
 
 class MutationPrunerBuilder(PluginBuilder):
-    plugin_name = "mutation-pruner"
+    name = "mutation-pruner"
 
     def __call__(self, *args, **kwargs):
         return MutationPruner()


### PR DESCRIPTION
For some plugins classes `plugin_name` was used, for others `name` was used and it's confusing