### PR TITLE
s/tostring/tobytes/

### DIFF
--- a/mythril/laser/ethereum/transaction/transaction_models.py
+++ b/mythril/laser/ethereum/transaction/transaction_models.py
@@ -251,7 +251,7 @@ class ContractCreationTransaction(BaseTransaction):
             self.return_data = None
             raise TransactionEndSignal(global_state, revert=revert)
 
-        contract_code = bytes.hex(array.array("B", return_data).tostring())
+        contract_code = bytes.hex(array.array("B", return_data).tobytes())
 
         global_state.environment.active_account.code.assign_bytecode(contract_code)
         self.return_data = str(


### PR DESCRIPTION
tostring() has been deprecated since 3.2 and removed in 3.9

ref: https://docs.python.org/3/library/array.html#array.array.tobytes