### PR TITLE
Bugfix for lost leading zeros in address, refactor

### DIFF
--- a/mythril/laser/ethereum/state/world_state.py
+++ b/mythril/laser/ethereum/state/world_state.py
@@ -82,8 +82,9 @@ class WorldState:
         """
 
         if isinstance(addr, str):
-            addr_bitvec = symbol_factory.BitVecVal(int(addr, 16), 256)
-        elif isinstance(addr, int):
+            addr = int(addr, 16)
+
+        if isinstance(addr, int):
             addr_bitvec = symbol_factory.BitVecVal(addr, 256)
         elif not isinstance(addr, BitVec):
             addr_bitvec = symbol_factory.BitVecVal(int(addr, 16), 256)
@@ -106,17 +107,6 @@ class WorldState:
                 )
             except:
                 # Initial balance will be a symbolic variable
-                pass
-        elif isinstance(addr, str):
-            try:
-                balance = dynamic_loader.read_balance(addr)
-                return self.create_account(
-                    balance=balance,
-                    address=addr_bitvec.value,
-                    dynamic_loader=dynamic_loader,
-                    code=dynamic_loader.dynld(addr),
-                )
-            except:
                 pass
 
         return self.create_account(


### PR DESCRIPTION
Noticed that when my contract had a "0x0ABCD..." dependency, Mythril sent the eth_getBalance request to my RPC with address "0xABCD.." instead.
Naturally, my RPC returned an error. Ultimately, there is an error somewhere between converting integers to strings, that loses leading zeros on addresses.

This patch fixes this bug, and further simplifies the two cases of isinstance(addr, int) and isinstance(addr, str) by merging them. Less duplicated code, less bugs.