### PR TITLE
Fix bug during checking potential issues

### DIFF
--- a/mythril/analysis/potential_issues.py
+++ b/mythril/analysis/potential_issues.py
@@ -81,12 +81,14 @@ def check_potential_issues(state: GlobalState) -> None:
     :return:
     """
     annotation = get_potential_issues_annotation(state)
+    unsat_potential_issues = []
     for potential_issue in annotation.potential_issues:
         try:
             transaction_sequence = get_transaction_sequence(
                 state, state.world_state.constraints + potential_issue.constraints
             )
         except UnsatError:
+            unsat_potential_issues.append(potential_issue)
             continue
 
         potential_issue.detector.cache.add(potential_issue.address)
@@ -105,3 +107,4 @@ def check_potential_issues(state: GlobalState) -> None:
                 transaction_sequence=transaction_sequence,
             )
         )
+    annotation.potential_issues = unsat_potential_issues

--- a/mythril/analysis/potential_issues.py
+++ b/mythril/analysis/potential_issues.py
@@ -89,7 +89,6 @@ def check_potential_issues(state: GlobalState) -> None:
         except UnsatError:
             continue
 
-        annotation.potential_issues.remove(potential_issue)
         potential_issue.detector.cache.add(potential_issue.address)
         potential_issue.detector.issues.append(
             Issue(


### PR DESCRIPTION
In the original code, Mythril removes the potential_issue in the loop.
However, in Python, during a loop of a list, removing an item will make things go wrong.
Talk is cheap, lets try the following code:

```python
myList = [1,2,3,4,5,6]
for i in myList:
    print(i)
    myList.remove(i)
```

It only prints (1,3,5), and (2,4,6) remains.

The same things go wrong in Mythril, as it just skip some potential issues.
For example, if the len(potential_issues) is 10, it might just check 6 SMT of them.

In Mythril's funciton, after checking a potential_issue, I think there is no need to remove it from the list.
Hence, deleting the ```remove``` code should work for this bug.