### PR TITLE
Fix py-evm version

### DIFF
--- a/mythril/analysis/module/modules/integer.py
+++ b/mythril/analysis/module/modules/integer.py
@@ -162,7 +162,9 @@ class IntegerArithmetics(DetectionModule):
     def _handle_exp(self, state):
         op0, op1 = self._get_args(state)
 
-        if op1.value == 0 or op0.value < 2:
+        if (op1.symbolic is False and op1.value == 0) or (
+            op0.symbolic is False and op0.value < 2
+        ):
             return
         if op0.symbolic and op1.symbolic:
             constraint = And(

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pyparsing<3,>=2.0.2
 pytest-cov
 pytest_mock
 requests
-rlp
+rlp<3.0.0
 semantic_version
 transaction>=2.2.1
 typing-extensions<4,>=3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ eth-utils<2
 jinja2>=2.9
 mock
 persistent>=4.2.0
+trie<2.0.0
 py-flags
 py-evm
 pysha3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ coincurve
 configparser>=3.5.0
 coverage
 py_ecc<5.0.0,>=1.4.7
-eth_abi
-eth-account
+eth_abi<3.0.0,>=2.0.0b4
+eth-account<0.6.0,>=0.5.6
 ethereum-input-decoder>=0.2.2
 eth-hash>=0.3.1
 eth-keyfile>=0.5.1
@@ -18,7 +18,7 @@ jinja2>=2.9
 mock
 persistent>=4.2.0
 py-flags
-py-evm
+py-evm==0.4.0a4
 pysha3
 py-solc-x
 py-solc

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ jinja2>=2.9
 mock
 persistent>=4.2.0
 py-flags
-py-evm==0.4.0a1
+py-evm
 pysha3
 py-solc-x
 py-solc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-blake2b-py
 coloredlogs>=10.0
 coincurve
 configparser>=3.5.0
@@ -12,11 +11,13 @@ eth-keyfile>=0.5.1
 eth-keys>=0.2.0b3
 eth-rlp>=0.1.0
 eth-tester
+eth-typing<3.0.0,>=2.1.0
+eth-utils<2
 jinja2>=2.9
 mock
 persistent>=4.2.0
 py-flags
-py-evm
+py-evm==0.5.0a1
 pysha3
 py-solc-x
 py-solc
@@ -25,7 +26,7 @@ pyparsing<3,>=2.0.2
 pytest-cov
 pytest_mock
 requests
-rlp>=3,<4
+rlp<3
 semantic_version
 transaction>=2.2.1
 typing-extensions<4,>=3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ jinja2>=2.9
 mock
 persistent>=4.2.0
 py-flags
-py-evm==0.3.0a18
+py-evm==0.4.0a1
 pysha3
 py-solc-x
 py-solc

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ eth-hash>=0.3.1
 eth-keyfile>=0.5.1
 eth-keys<0.4.0,>=0.2.1
 eth-rlp>=0.1.0
-eth-tester>0.5.0
 eth-typing<3.0.0,>=2.1.0
 eth-utils<2
 jinja2>=2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,12 +12,9 @@ eth-keyfile>=0.5.1
 eth-keys>=0.2.0b3
 eth-rlp>=0.1.0
 eth-tester
-eth-typing<3.0.0,>=2.1.0
-eth-utils<2
 jinja2>=2.9
 mock
 persistent>=4.2.0
-trie<2.0.0
 py-flags
 py-evm
 pysha3
@@ -28,7 +25,7 @@ pyparsing<3,>=2.0.2
 pytest-cov
 pytest_mock
 requests
-rlp<3.0.0
+rlp>=3,<4
 semantic_version
 transaction>=2.2.1
 typing-extensions<4,>=3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 coloredlogs>=10.0
-coincurve
+coincurve>=13.0.0
+asn1crypto>=0.22.0
 configparser>=3.5.0
 coverage
 py_ecc<5.0.0,>=1.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ coloredlogs>=10.0
 coincurve>=13.0.0
 asn1crypto>=0.22.0
 configparser>=3.5.0
-coverage
+coverage>6.0
 py_ecc<5.0.0,>=1.4.7
 eth_abi<3.0.0,>=2.0.0b4
 eth-account<0.6.0,>=0.5.6
@@ -11,7 +11,7 @@ eth-hash>=0.3.1
 eth-keyfile>=0.5.1
 eth-keys>=0.2.0b3
 eth-rlp>=0.1.0
-eth-tester
+eth-tester>0.5.0
 eth-typing<3.0.0,>=2.1.0
 eth-utils<2
 jinja2>=2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+blake2b-py
 coloredlogs>=10.0
 coincurve>=13.0.0
 asn1crypto>=0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ jinja2>=2.9
 mock
 persistent>=4.2.0
 py-flags
-py-evm==0.4.0a4
+py-evm==0.3.0a18
 pysha3
 py-solc-x
 py-solc


### PR DESCRIPTION
Fix py-evm version and restrict others. py-evm can only be fixed since their versions are non-numerical due to it being in alpha.