### PR TITLE
Fix the leaking file descriptor when returning a z3 smt check result

### DIFF
--- a/mythril/laser/smt/solver/solver.py
+++ b/mythril/laser/smt/solver/solver.py
@@ -54,13 +54,14 @@ class BaseSolver(Generic[T]):
         :return: The evaluated result which is either of sat, unsat or unknown
         """
         old_stdout = sys.stdout
-        sys.stdout = open(os.devnull, "w")
-        try:
-            evaluate = self.raw.check(args)
-        except z3.z3types.Z3Exception as e:
-            # Some requests crash the solver
-            evaluate = z3.unknown
-            log.info(f"Encountered Z3 exception when checking the constraints: {e}")
+        with open(os.devnull, "w") as dev_null_fd:
+            sys.stdout = dev_null_fd
+            try:
+                evaluate = self.raw.check(args)
+            except z3.z3types.Z3Exception as e:
+                # Some requests crash the solver
+                evaluate = z3.unknown
+                log.info(f"Encountered Z3 exception when checking the constraints: {e}")
         sys.stdout = old_stdout
         return evaluate
 


### PR DESCRIPTION
When using `mythril` as a library and applying it to multiple inputs within the same process instance this issue eventually leads to the following exception:
```
CRITICAL:mythril.mythril.mythril_analyzer:Exception occurred, aborting analysis. Please report this issue to the Mythril GitHub page.
Traceback (most recent call last):
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/mythril/mythril_analyzer.py", line 149, in fire_lasers
    sym = SymExecWrapper(
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/analysis/symbolic.py", line 214, in __init__
    self.laser.sym_exec(world_state=world_state, target_address=address.value)
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/laser/ethereum/svm.py", line 155, in sym_exec
    self._execute_transactions(symbol_factory.BitVecVal(target_address, 256))
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/laser/ethereum/svm.py", line 201, in _execute_transactions
    self.open_states = [
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/laser/ethereum/svm.py", line 202, in <listcomp>
    state for state in self.open_states if state.constraints.is_possible
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/laser/ethereum/state/constraints.py", line 33, in is_possible
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/support/model.py", line 58, in get_model
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/laser/smt/solver/solver_statistics.py", line 19, in function_wrapper
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/laser/smt/solver/solver.py", line 57, in check
OSError: [Errno 24] Too many open files: '/dev/null'

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/izeigerman/github/eth-explorer/ethplorer/client.py", line 53, in print_vulnarable_contracts
  File "/Users/izeigerman/github/eth-explorer/ethplorer/client.py", line 24, in find_vulnarable_contracts
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/mythril/mythril_disassembler.py", line 109, in load_from_bytecode
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/ethereum/evmcontract.py", line 37, in __init__
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/disassembler/disassembly.py", line 32, in __init__
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/disassembler/disassembly.py", line 46, in assign_bytecode
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/disassembler/disassembly.py", line 86, in get_function_info
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/support/signatures.py", line 204, in get
  File "/Users/izeigerman/github/eth-explorer/.venv/lib/python3.9/site-packages/mythril/support/signatures.py", line 99, in __enter__
sqlite3.OperationalError: unable to open database file
```