### PR TITLE
remove depth for jump

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -1549,7 +1549,6 @@ class Instruction:
 
         # manually set PC to destination
         new_state.mstate.pc = index
-        new_state.mstate.depth += 1
 
         return [new_state]
 


### PR DESCRIPTION
fixes #1627.
For some reason, we were updating depth for jump instruction.