### PR TITLE
Support py36 through py39

### DIFF
--- a/mythril/support/support_utils.py
+++ b/mythril/support/support_utils.py
@@ -2,7 +2,7 @@
 from functools import lru_cache
 from typing import Dict
 import logging
-import _pysha3
+from eth_hash.auto import keccak
 
 log = logging.getLogger(__name__)
 
@@ -39,24 +39,22 @@ def get_code_hash(code) -> str:
 
     code = code[2:] if code[:2] == "0x" else code
     try:
-        keccak = _pysha3.keccak_256()
-        keccak.update(bytes.fromhex(code))
-        return "0x" + keccak.hexdigest()
+        hash_ = keccak(bytes.fromhex(code))
+        return "0x" + hash_.hex()
     except ValueError:
         log.debug("Unable to change the bytecode to bytes. Bytecode: {}".format(code))
         return ""
 
 
 def sha3(value):
-    keccak = _pysha3.keccak_256()
     if type(value) == str:
         if value[:2] == "0x":
-            keccak.update(bytes.fromhex(value))
+            new_hash = keccak(bytes.fromhex(value))
         else:
-            keccak.update(value.encode())
+            new_hash = keccak(value.encode())
     else:
-        keccak.update(value)
-    return keccak.digest()
+        new_hash = keccak(value)
+    return new_hash
 
 
 def zpad(x, l):

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ mock
 persistent>=4.2.0
 py-flags
 py-evm==0.5.0a1
-pysha3
 py-solc-x
 py-solc
 pytest>=3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ semantic_version
 transaction>=2.2.1
 typing-extensions<4,>=3.7.4
 z3-solver>=4.8.8.0
-pysha3
 matplotlib
 pre-commit
 certifi>=2020.06.20

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36, py38, py39
 
 [testenv]
 deps =
@@ -40,6 +40,55 @@ commands =
         --disable-pytest-warnings \
         {posargs}
 
+[testenv:py38]
+basepython = python3.8
+setenv =
+    COVERAGE_FILE = .coverage.{envname}
+deps =
+    mypy==0.782
+    pytest
+    pytest-mock
+    pytest-cov
+    
+passenv = MYTHRIL_DIR INFURA_ID
+whitelist_externals = mkdir
+commands =
+    mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional mythril
+    mkdir -p {toxinidir}/tests/testdata/outputs_current/
+    mkdir -p {toxinidir}/tests/testdata/outputs_current_laser_result/
+    py.test -v \
+        --cov=mythril \
+        --cov-config=tox.ini \
+        --cov-report=xml:{toxworkdir}/output/{envname}/coverage.xml \
+        --cov-report=html:{toxworkdir}/output/{envname}/covhtml \
+        --junitxml={toxworkdir}/output/{envname}/junit.xml \
+        --disable-pytest-warnings \
+        {posargs}
+
+[testenv:py39]
+basepython = python3.9
+setenv =
+    COVERAGE_FILE = .coverage.{envname}
+deps =
+    mypy==0.782
+    pytest
+    pytest-mock
+    pytest-cov
+    
+passenv = MYTHRIL_DIR INFURA_ID
+whitelist_externals = mkdir
+commands =
+    mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional mythril
+    mkdir -p {toxinidir}/tests/testdata/outputs_current/
+    mkdir -p {toxinidir}/tests/testdata/outputs_current_laser_result/
+    py.test -v \
+        --cov=mythril \
+        --cov-config=tox.ini \
+        --cov-report=xml:{toxworkdir}/output/{envname}/coverage.xml \
+        --cov-report=html:{toxworkdir}/output/{envname}/covhtml \
+        --junitxml={toxworkdir}/output/{envname}/junit.xml \
+        --disable-pytest-warnings \
+        {posargs}
 
 
 [coverage:report]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py38, py39
+envlist = python3.6, python3.8, python3.9
 
 [testenv]
 deps =


### PR DESCRIPTION
Switch to py-evm libraries. Wait out for newly released versions of blake2b-py for python 3.10,  since reimplementing them is hard.