### PR TITLE
Remove additional python runs in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python3.6, python3.8, python3.9
+envlist = python3.6, python3.9
 
 [testenv]
 deps =


### PR DESCRIPTION
Since `geth` gets killed by CI after some time, it is better to run only the necessary python versions.